### PR TITLE
Handle config watcher restart on stream close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bluetooth: use alias instead of name for device name
 - Airplane button fail when the `rfkill` returns an error or is not present
 
+## [0.1.3] - 2025-09-26
+
+### Fixed
+
+- Restore the configuration file watcher when the inotify stream closes and avoid tight loops on stream shutdown.
+
 ## [0.1.1] - 2025-05-23
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2260,7 +2260,7 @@ dependencies = [
 
 [[package]]
 name = "hydebar"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "hydebar"
 description = "A ready to go Wayland status bar for Hyprland"
 homepage = "https://github.com/MalpenZibo/hydebar"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 rust-version = "1.90"
 


### PR DESCRIPTION
## Summary
- restart the configuration watcher when the inotify stream closes and log/watch for restart errors
- extract reusable helpers for interpreting events and add a smoke test covering stream shutdown handling
- bump the crate version to 0.1.3, record the fix in the changelog, and refresh Cargo.lock (including the cocoa-foundation downgrade)

## Testing
- cargo +nightly fmt --
- cargo +1.90.0 clippy --locked -- -D warnings
- cargo +1.90.0 build --locked --all-targets
- cargo +1.90.0 test --locked --all
- cargo +1.90.0 doc --locked --no-deps
- cargo audit
- cargo deny check (fails: cannot reach advisory-db)


------
https://chatgpt.com/codex/tasks/task_e_68d5e9a4ba14832b93779c6f2718a52a