### PR TITLE
Refine brightness service error handling

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -7,8 +7,8 @@ use crate::{
     menu::{MenuSize, MenuType, menu_wrapper},
     modules::{
         self,
-        battery::Battery,
         app_launcher::AppLauncher,
+        battery::Battery,
         clipboard::Clipboard,
         clock::Clock,
         custom_module::Custom,
@@ -26,7 +26,7 @@ use crate::{
     outputs::{HasOutput, Outputs},
     position_button::ButtonUIRef,
     services::{Service, ServiceEvent, brightness::BrightnessCommand, tray::TrayEvent},
-    style::{hydebar_theme, backdrop_color, darken_color},
+    style::{backdrop_color, darken_color, hydebar_theme},
     utils,
 };
 use flexi_logger::LoggerHandle;

--- a/src/services/brightness/error.rs
+++ b/src/services/brightness/error.rs
@@ -1,0 +1,97 @@
+use std::sync::Arc;
+
+use masterror::Error;
+use zbus::Error as ZbusError;
+
+/// Error type emitted by the brightness service.
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum BrightnessError {
+    /// Filesystem interaction failed while reading or writing brightness data.
+    #[error("failed to access backlight filesystem: {context}")]
+    Filesystem { context: Arc<str> },
+
+    /// Parsing the brightness level from sysfs failed.
+    #[error("failed to parse brightness value: {context}")]
+    Parse { context: Arc<str> },
+
+    /// DBus call to the system brightness controller failed.
+    #[error("failed to interact with system bus: {context}")]
+    DBus { context: Arc<str> },
+
+    /// No usable backlight device was detected on the system.
+    #[error("no backlight devices found")]
+    MissingDevice,
+}
+
+impl BrightnessError {
+    fn arc_from(value: impl Into<String>) -> Arc<str> {
+        Arc::<str>::from(value.into())
+    }
+
+    /// Create a filesystem error with contextual information.
+    pub fn filesystem(context: impl Into<String>) -> Self {
+        Self::Filesystem {
+            context: Self::arc_from(context),
+        }
+    }
+
+    /// Create a parse error with contextual information.
+    pub fn parse(context: impl Into<String>) -> Self {
+        Self::Parse {
+            context: Self::arc_from(context),
+        }
+    }
+
+    /// Create a DBus error with contextual information.
+    pub fn dbus(context: impl Into<String>) -> Self {
+        Self::DBus {
+            context: Self::arc_from(context),
+        }
+    }
+}
+
+impl From<std::io::Error> for BrightnessError {
+    fn from(value: std::io::Error) -> Self {
+        BrightnessError::filesystem(value.to_string())
+    }
+}
+
+impl From<std::num::ParseIntError> for BrightnessError {
+    fn from(value: std::num::ParseIntError) -> Self {
+        BrightnessError::parse(value.to_string())
+    }
+}
+
+impl From<ZbusError> for BrightnessError {
+    fn from(value: ZbusError) -> Self {
+        BrightnessError::dbus(value.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::BrightnessError;
+
+    #[test]
+    fn converts_io_errors() {
+        let err = BrightnessError::from(std::io::Error::new(std::io::ErrorKind::Other, "boom"));
+        assert!(matches!(
+            err,
+            BrightnessError::Filesystem { ref context } if context.as_ref() == "boom"
+        ));
+    }
+
+    #[test]
+    fn converts_parse_errors() {
+        let err = "foo".parse::<u32>().unwrap_err();
+        let err = BrightnessError::from(err);
+        assert!(matches!(err, BrightnessError::Parse { .. }));
+    }
+
+    #[test]
+    fn converts_zbus_errors() {
+        let err = zbus::Error::Failure("failure".into());
+        let err = BrightnessError::from(err);
+        assert!(matches!(err, BrightnessError::DBus { .. }));
+    }
+}


### PR DESCRIPTION
## Summary
- introduce a dedicated `BrightnessError` based on `masterror` with conversions for filesystem, parse, and D-Bus failures
- refactor the brightness service to propagate structured errors through helper methods, event loops, and commands
- add tests covering error conversions and missing-device handling while updating imports impacted by formatting

## Testing
- `cargo +nightly fmt --`
- `cargo +nightly clippy -- -D warnings` *(fails: system dependency `xkbcommon` missing)*
- `cargo +nightly test --all` *(fails: system dependency `xkbcommon` missing)*
- `cargo +nightly build --all-targets` *(fails: system dependency `xkbcommon` missing)*
- `cargo +nightly doc --no-deps` *(fails: system dependency `xkbcommon` missing)*
- `cargo audit`
- `cargo deny check` *(installation attempt for cargo-deny aborted due to prolonged compilation; check not run)*

------
https://chatgpt.com/codex/tasks/task_e_68d5f476f3d0832bb15a4d772d2f1706