### PR TITLE
Refine idle inhibitor error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bluetooth: use alias instead of name for device name
 - Airplane button fail when the `rfkill` returns an error or is not present
 
+## [0.2.0] - 2025-09-26
+
+### Added
+
+- Introduced a dedicated `IdleInhibitorError` type for the idle inhibitor service.
+
+### Changed
+
+- `IdleInhibitorManager::new` now returns `Result<Self, IdleInhibitorError>` and surfaces initialization failures explicitly.
+- Idle inhibitor initialization tests cover both missing and complete Wayland global scenarios.
+
 ## [0.1.3] - 2025-09-26
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "hydebar"
 description = "A ready to go Wayland status bar for Hyprland"
 homepage = "https://github.com/MalpenZibo/hydebar"
-version = "0.1.3"
+version = "0.2.0"
 edition = "2024"
 rust-version = "1.90"
 

--- a/src/modules/settings/mod.rs
+++ b/src/modules/settings/mod.rs
@@ -31,7 +31,7 @@ use iced::{
     widget::{Column, Row, Space, button, column, container, horizontal_space, row, text},
     window::Id,
 };
-use log::info;
+use log::{info, warn};
 use upower::UPowerMessage;
 
 pub mod audio;
@@ -54,12 +54,20 @@ pub struct Settings {
 
 impl Default for Settings {
     fn default() -> Self {
+        let idle_inhibitor = match IdleInhibitorManager::new() {
+            Ok(manager) => Some(manager),
+            Err(err) => {
+                warn!("Failed to initialize idle inhibitor: {err}");
+                None
+            }
+        };
+
         Settings {
             audio: None,
             brightness: None,
             network: None,
             bluetooth: None,
-            idle_inhibitor: IdleInhibitorManager::new(),
+            idle_inhibitor,
             sub_menu: None,
             upower: None,
             password_dialog: None,

--- a/src/services/idle_inhibitor/error.rs
+++ b/src/services/idle_inhibitor/error.rs
@@ -1,0 +1,136 @@
+use std::sync::Arc;
+
+use masterror::Error;
+use wayland_client::{ConnectError, DispatchError};
+
+/// Error type emitted by the idle inhibitor service.
+///
+/// The error captures failures to connect to the Wayland compositor, missing
+/// globals announced by the compositor, and dispatch roundtrip errors.
+///
+/// # Examples
+/// ```ignore
+/// use hydebar::services::idle_inhibitor::IdleInhibitorError;
+///
+/// let err = IdleInhibitorError::missing_idle_inhibit_manager();
+/// assert!(matches!(err, IdleInhibitorError::MissingGlobal { .. }));
+/// ```
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum IdleInhibitorError {
+    /// Establishing a Wayland connection failed.
+    #[error("failed to connect to wayland compositor: {context}")]
+    Connection { context: Arc<str> },
+
+    /// A required Wayland global was not advertised by the compositor.
+    #[error("missing wayland global: {global}")]
+    MissingGlobal { global: MissingGlobal },
+
+    /// Dispatching Wayland events failed during a roundtrip.
+    #[error("failed to dispatch wayland events: {context}")]
+    Dispatch { context: Arc<str> },
+}
+
+impl IdleInhibitorError {
+    fn arc_from(value: impl Into<String>) -> Arc<str> {
+        Arc::<str>::from(value.into())
+    }
+
+    /// Create a connection error with contextual information.
+    pub fn connection(context: impl Into<String>) -> Self {
+        Self::Connection {
+            context: Self::arc_from(context),
+        }
+    }
+
+    /// Create a dispatch error with contextual information.
+    pub fn dispatch(context: impl Into<String>) -> Self {
+        Self::Dispatch {
+            context: Self::arc_from(context),
+        }
+    }
+
+    /// Create an error describing a missing compositor global.
+    pub fn missing_compositor() -> Self {
+        Self::MissingGlobal {
+            global: MissingGlobal::Compositor,
+        }
+    }
+
+    /// Create an error describing a missing idle inhibit manager global.
+    pub fn missing_idle_inhibit_manager() -> Self {
+        Self::MissingGlobal {
+            global: MissingGlobal::IdleInhibitManager,
+        }
+    }
+
+    /// Create an error describing a missing compositor surface global.
+    pub fn missing_surface() -> Self {
+        Self::MissingGlobal {
+            global: MissingGlobal::Surface,
+        }
+    }
+}
+
+impl From<ConnectError> for IdleInhibitorError {
+    fn from(value: ConnectError) -> Self {
+        IdleInhibitorError::connection(value.to_string())
+    }
+}
+
+impl From<DispatchError> for IdleInhibitorError {
+    fn from(value: DispatchError) -> Self {
+        IdleInhibitorError::dispatch(value.to_string())
+    }
+}
+
+/// Enumeration of required Wayland globals for idle inhibition.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MissingGlobal {
+    /// The `wl_compositor` interface.
+    Compositor,
+    /// The surface derived from `wl_compositor`.
+    Surface,
+    /// The `zwp_idle_inhibit_manager_v1` interface.
+    IdleInhibitManager,
+}
+
+impl core::fmt::Display for MissingGlobal {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            MissingGlobal::Compositor => f.write_str("wl_compositor"),
+            MissingGlobal::Surface => f.write_str("wl_surface"),
+            MissingGlobal::IdleInhibitManager => f.write_str("zwp_idle_inhibit_manager_v1"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{IdleInhibitorError, MissingGlobal};
+
+    #[test]
+    fn connection_error_converts() {
+        let err = IdleInhibitorError::from(wayland_client::ConnectError::NoCompositorListening);
+        assert!(matches!(err, IdleInhibitorError::Connection { .. }));
+    }
+
+    #[test]
+    fn dispatch_error_converts() {
+        let err = IdleInhibitorError::from(wayland_client::DispatchError::MissingData);
+        assert!(matches!(err, IdleInhibitorError::Dispatch { .. }));
+    }
+
+    #[test]
+    fn missing_global_display_matches_variant() {
+        let err = IdleInhibitorError::missing_idle_inhibit_manager();
+        assert_eq!(
+            format!("{err}"),
+            "missing wayland global: zwp_idle_inhibit_manager_v1"
+        );
+    }
+
+    #[test]
+    fn missing_global_variants_are_distinct() {
+        assert_ne!(MissingGlobal::Compositor, MissingGlobal::Surface);
+    }
+}


### PR DESCRIPTION
## Summary
- introduce a dedicated `IdleInhibitorError` and require `IdleInhibitorManager::new` to return a typed `Result`
- ensure idle inhibitor wiring logs initialization failures instead of discarding them
- record the API change in the changelog and bump the crate version to 0.2.0

## Testing
- `cargo +nightly fmt --`
- `cargo +1.90.0 clippy -- -D warnings` *(fails: existing brightness compilation errors unrelated to this change)*
- `cargo +1.90.0 test --all` *(not run: blocked by the same upstream compilation errors)*

------
https://chatgpt.com/codex/tasks/task_e_68d5faaa80fc832b8e8e0c04d80d1e7d