### PR TITLE
Introduce PrivacyError and harden privacy service listeners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bluetooth: use alias instead of name for device name
 - Airplane button fail when the `rfkill` returns an error or is not present
 
+## [0.2.1] - 2025-09-26
+
+### Changed
+
+- Privacy service now exposes structured `PrivacyError` values and gracefully falls back when the webcam device is absent.
+
+### Fixed
+
+- Report PipeWire and inotify listener initialisation failures without panicking, allowing the UI to react to privacy service errors.
+
 ## [0.2.0] - 2025-09-26
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2260,7 +2260,7 @@ dependencies = [
 
 [[package]]
 name = "hydebar"
-version = "0.1.3"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "hydebar"
 description = "A ready to go Wayland status bar for Hyprland"
 homepage = "https://github.com/MalpenZibo/hydebar"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 rust-version = "1.90"
 

--- a/src/services/idle_inhibitor/error.rs
+++ b/src/services/idle_inhibitor/error.rs
@@ -110,13 +110,18 @@ mod tests {
 
     #[test]
     fn connection_error_converts() {
-        let err = IdleInhibitorError::from(wayland_client::ConnectError::NoCompositorListening);
+        let err = IdleInhibitorError::from(wayland_client::ConnectError::NoCompositor);
         assert!(matches!(err, IdleInhibitorError::Connection { .. }));
     }
 
     #[test]
     fn dispatch_error_converts() {
-        let err = IdleInhibitorError::from(wayland_client::DispatchError::MissingData);
+        let err = IdleInhibitorError::from(wayland_client::DispatchError::Backend(
+            wayland_client::backend::WaylandError::from(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "dispatch",
+            )),
+        ));
         assert!(matches!(err, IdleInhibitorError::Dispatch { .. }));
     }
 

--- a/src/services/privacy.rs
+++ b/src/services/privacy.rs
@@ -1,4 +1,7 @@
 use super::{ReadOnlyService, ServiceEvent};
+pub mod error;
+
+use self::error::PrivacyError;
 use iced::{
     Subscription,
     futures::{
@@ -8,24 +11,36 @@ use iced::{
 };
 use inotify::{EventMask, Inotify, WatchMask};
 use log::{debug, error, info, warn};
-use pipewire::{context::Context, main_loop::MainLoop};
-use std::{any::TypeId, fs, ops::Deref, path::Path, thread};
-use tokio::sync::mpsc::{UnboundedReceiver, unbounded_channel};
+use pipewire::{context::Context, core::Core, main_loop::MainLoop};
+use std::{any::TypeId, fs, future::Future, ops::Deref, path::Path, pin::Pin, thread};
+use tokio::sync::{
+    mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel},
+    oneshot,
+};
 
 const WEBCAM_DEVICE_PATH: &str = "/dev/video0";
 
+type PrivacyStream = Pin<Box<dyn Stream<Item = PrivacyEvent> + Send>>;
+
+/// Media class reported by PipeWire for an application node.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum Media {
+    /// The node represents a video stream, typically screen sharing.
     Video,
+    /// The node represents an audio stream, typically microphone usage.
     Audio,
 }
 
+/// Metadata describing an application node that is accessing privacy-sensitive resources.
 #[derive(Debug, Clone)]
 pub struct ApplicationNode {
+    /// Identifier assigned by PipeWire.
     pub id: u32,
+    /// Media classification of the node.
     pub media: Media,
 }
 
+/// Aggregated privacy information exposed to UI consumers.
 #[derive(Debug, Clone)]
 pub struct PrivacyData {
     nodes: Vec<ApplicationNode>,
@@ -40,23 +55,28 @@ impl PrivacyData {
         }
     }
 
+    /// Returns `true` when no privacy-sensitive resources are currently in use.
     pub fn no_access(&self) -> bool {
         self.nodes.is_empty() && self.webcam_access == 0
     }
 
+    /// Returns `true` when an audio input node is active.
     pub fn microphone_access(&self) -> bool {
         self.nodes.iter().any(|n| n.media == Media::Audio)
     }
 
+    /// Returns `true` while the webcam device is reported as in use.
     pub fn webcam_access(&self) -> bool {
         self.webcam_access > 0
     }
 
+    /// Returns `true` when a video capture node (typically screen sharing) is active.
     pub fn screenshare_access(&self) -> bool {
         self.nodes.iter().any(|n| n.media == Media::Video)
     }
 }
 
+/// Service exposing read-only privacy state to interested modules.
 #[derive(Debug, Clone)]
 pub struct PrivacyService {
     data: PrivacyData,
@@ -71,72 +91,136 @@ impl Deref for PrivacyService {
 }
 
 impl PrivacyService {
-    async fn create_pipewire_listener() -> anyhow::Result<UnboundedReceiver<PrivacyEvent>> {
+    async fn create_pipewire_listener() -> Result<UnboundedReceiver<PrivacyEvent>, PrivacyError> {
         let (tx, rx) = unbounded_channel::<PrivacyEvent>();
+        let (init_tx, init_rx) = oneshot::channel::<Result<(), PrivacyError>>();
 
-        thread::spawn(move || {
-            let mainloop = MainLoop::new(None).unwrap();
-            let context = Context::new(&mainloop).unwrap();
-            let core = context.connect(None).unwrap();
-            let registry = core.get_registry().unwrap();
+        let builder = thread::Builder::new().name("privacy-pipewire".into());
+        builder
+            .spawn(move || {
+                struct PipewireRuntime {
+                    mainloop: MainLoop,
+                    _context: Context,
+                    _core: Core,
+                    _listener: pipewire::registry::Listener,
+                }
 
-            let _listener = registry
-                .add_listener_local()
-                .global({
-                    let tx = tx.clone();
-                    move |global| {
-                        if let Some(props) = global.props {
-                            if let Some(media) = props.get("media.class").filter(|v| {
-                                v == &"Stream/Input/Video" || v == &"Stream/Input/Audio"
-                            }) {
-                                debug!("New global: {global:?}");
-                                let _ = tx.send(PrivacyEvent::AddNode(ApplicationNode {
-                                    id: global.id,
-                                    media: if media == "Stream/Input/Video" {
-                                        Media::Video
-                                    } else {
-                                        Media::Audio
-                                    },
-                                }));
-                            }
+                impl PipewireRuntime {
+                    fn new(tx: UnboundedSender<PrivacyEvent>) -> Result<Self, PrivacyError> {
+                        let mainloop = MainLoop::new(None)
+                            .map_err(|err| PrivacyError::pipewire_mainloop(err.to_string()))?;
+                        let context = Context::new(&mainloop)
+                            .map_err(|err| PrivacyError::pipewire_context(err.to_string()))?;
+                        let core = context
+                            .connect(None)
+                            .map_err(|err| PrivacyError::pipewire_core(err.to_string()))?;
+                        let registry = core
+                            .get_registry()
+                            .map_err(|err| PrivacyError::pipewire_registry(err.to_string()))?;
+                        let remove_tx = tx.clone();
+                        let listener = registry
+                            .add_listener_local()
+                            .global({
+                                let tx = tx.clone();
+                                move |global| {
+                                    if let Some(props) = global.props {
+                                        if let Some(media) = props.get("media.class").filter(|v| {
+                                            *v == "Stream/Input/Video" || *v == "Stream/Input/Audio"
+                                        }) {
+                                            debug!("New global: {global:?}");
+                                            let event = PrivacyEvent::AddNode(ApplicationNode {
+                                                id: global.id,
+                                                media: if media == "Stream/Input/Video" {
+                                                    Media::Video
+                                                } else {
+                                                    Media::Audio
+                                                },
+                                            });
+                                            if let Err(err) = tx.send(event) {
+                                                warn!(
+                                                    "Failed to forward PipeWire add event: {err}"
+                                                );
+                                            }
+                                        }
+                                    }
+                                }
+                            })
+                            .global_remove(move |id| {
+                                debug!("Remove global: {id}");
+                                if let Err(err) = remove_tx.send(PrivacyEvent::RemoveNode(id)) {
+                                    warn!("Failed to forward PipeWire remove event: {err}");
+                                }
+                            })
+                            .register();
+
+                        Ok(Self {
+                            mainloop,
+                            _context: context,
+                            _core: core,
+                            _listener: listener,
+                        })
+                    }
+
+                    fn run(self) {
+                        self.mainloop.run();
+                    }
+                }
+
+                match PipewireRuntime::new(tx) {
+                    Ok(runtime) => {
+                        if init_tx.send(Ok(())).is_err() {
+                            warn!("PipeWire initialisation receiver dropped before completion");
+                            return;
+                        }
+                        runtime.run();
+                        warn!("PipeWire mainloop exited");
+                    }
+                    Err(err) => {
+                        error!("Failed to initialise PipeWire: {err}");
+                        if init_tx.send(Err(err.clone())).is_err() {
+                            warn!("Unable to report PipeWire initialisation failure: {err}");
                         }
                     }
-                })
-                .global_remove({
-                    let tx = tx.clone();
-                    move |id| {
-                        debug!("Remove global: {id}");
-                        let _ = tx.send(PrivacyEvent::RemoveNode(id));
-                    }
-                })
-                .register();
+                }
+            })
+            .map_err(|err| {
+                PrivacyError::channel(format!("failed to spawn PipeWire listener thread: {err}"))
+            })?;
 
-            mainloop.run();
-
-            warn!("Pipewire mainloop exited");
-        });
-
-        Ok(rx)
+        match init_rx.await {
+            Ok(Ok(())) => Ok(rx),
+            Ok(Err(err)) => Err(err),
+            Err(_) => Err(PrivacyError::channel(
+                "failed to receive PipeWire initialisation result",
+            )),
+        }
     }
 
-    async fn webcam_listener() -> anyhow::Result<Box<dyn Stream<Item = PrivacyEvent> + Unpin + Send>>
-    {
-        let inotify = Inotify::init()?;
-
-        inotify.watches().add(
+    async fn webcam_listener() -> Result<PrivacyStream, PrivacyError> {
+        let inotify = Inotify::init().map_err(|err| PrivacyError::inotify_init(err.to_string()))?;
+        match inotify.watches().add(
             WEBCAM_DEVICE_PATH,
             WatchMask::CLOSE_WRITE
                 | WatchMask::CLOSE_NOWRITE
                 | WatchMask::DELETE_SELF
                 | WatchMask::OPEN
                 | WatchMask::ATTRIB,
-        )?;
+        ) {
+            Ok(_) => {}
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                return Err(PrivacyError::WebcamUnavailable);
+            }
+            Err(err) => {
+                return Err(PrivacyError::inotify_watch(err.to_string()));
+            }
+        }
 
         let buffer = [0; 512];
-        Ok(Box::new(
-            inotify
-                .into_event_stream(buffer)?
-                .filter_map(async move |event| match event {
+        let stream = inotify
+            .into_event_stream(buffer)
+            .map_err(|err| PrivacyError::inotify_init(err.to_string()))?
+            .filter_map(|event| async move {
+                match event {
                     Ok(event) => {
                         debug!("Webcam event: {event:?}");
                         match event.mask {
@@ -147,105 +231,153 @@ impl PrivacyService {
                             _ => None,
                         }
                     }
-                    _ => None,
-                })
-                .boxed(),
-        ))
-    }
-
-    async fn start_listening(state: State, output: &mut Sender<ServiceEvent<Self>>) -> State {
-        match state {
-            State::Init => {
-                let pipewire = Self::create_pipewire_listener().await;
-                let webcam = Self::webcam_listener().await;
-                match (pipewire, webcam) {
-                    (Ok(pipewire), Ok(webcam)) => {
-                        let data = PrivacyData::new();
-
-                        let _ = output
-                            .send(ServiceEvent::Init(PrivacyService { data }))
-                            .await;
-
-                        State::Active((pipewire, webcam))
-                    }
-                    (Err(pipewire_error), Ok(_)) => {
-                        error!("Failed to connect to pipewire: {pipewire_error}");
-
-                        State::Error
-                    }
-                    (Ok(pipewire), Err(webcam_error)) => {
-                        warn!("Failed to connect to webcam: {webcam_error}");
-
-                        State::Active((pipewire, Box::new(pending::<PrivacyEvent>().boxed())))
-                    }
-                    (Err(pipewire_error), Err(webcam_error)) => {
-                        error!("Failed to connect to pipewire: {pipewire_error}");
-                        error!("Failed to connect to webcam: {webcam_error}");
-
-                        State::Error
+                    Err(err) => {
+                        warn!("Failed to read webcam event: {err}");
+                        None
                     }
                 }
+            })
+            .boxed();
+
+        Ok(stream)
+    }
+
+    async fn emit_event(
+        output: &mut Sender<ServiceEvent<Self>>,
+        event: ServiceEvent<Self>,
+    ) -> Result<(), PrivacyError> {
+        output
+            .send(event)
+            .await
+            .map_err(|err| PrivacyError::channel(err.to_string()))
+    }
+
+    async fn start_listening(
+        state: State,
+        output: &mut Sender<ServiceEvent<Self>>,
+    ) -> Result<State, PrivacyError> {
+        Self::start_listening_with_factories(
+            state,
+            output,
+            Self::create_pipewire_listener,
+            Self::webcam_listener,
+        )
+        .await
+    }
+
+    async fn start_listening_with_factories<P, PFut, W, WFut>(
+        state: State,
+        output: &mut Sender<ServiceEvent<Self>>,
+        mut pipewire_factory: P,
+        mut webcam_factory: W,
+    ) -> Result<State, PrivacyError>
+    where
+        P: FnMut() -> PFut,
+        PFut: Future<Output = Result<UnboundedReceiver<PrivacyEvent>, PrivacyError>> + Send,
+        W: FnMut() -> WFut,
+        WFut: Future<Output = Result<PrivacyStream, PrivacyError>> + Send,
+    {
+        match state {
+            State::Init => {
+                let pipewire = pipewire_factory().await?;
+                let webcam = match webcam_factory().await {
+                    Ok(stream) => stream,
+                    Err(err @ PrivacyError::WebcamUnavailable) => {
+                        warn!("{err}");
+                        pending::<PrivacyEvent>().boxed()
+                    }
+                    Err(err) => return Err(err),
+                };
+
+                let data = PrivacyData::new();
+                Self::emit_event(output, ServiceEvent::Init(PrivacyService { data })).await?;
+
+                Ok(State::Active { pipewire, webcam })
             }
-            State::Active((mut pipewire, mut webcam)) => {
+            State::Active {
+                mut pipewire,
+                mut webcam,
+            } => {
                 info!("Listening for privacy events");
+
+                let mut webcam_pin = webcam.as_mut();
+                let mut webcam_future = webcam_pin.next().fuse();
 
                 select! {
                     value = pipewire.recv().fuse() => {
                         match value {
                             Some(event) => {
-                                let _ = output.send(ServiceEvent::Update(event)).await;
+                                Self::emit_event(output, ServiceEvent::Update(event)).await?;
                             }
                             None => {
-                                error!("Pipewire listener exited");
+                                error!("PipeWire listener exited unexpectedly");
+                                return Err(PrivacyError::channel(
+                                    "pipewire listener closed unexpectedly",
+                                ));
                             }
                         }
-                    },
-                    value = webcam.next().fuse() => {
+                    }
+                    value = webcam_future => {
                         match value {
                             Some(event) => {
-                                let _ = output.send(ServiceEvent::Update(event)).await;
+                                Self::emit_event(output, ServiceEvent::Update(event)).await?;
                             }
                             None => {
-                                error!("Webcam listener exited");
+                                error!("Webcam listener exited unexpectedly");
+                                return Err(PrivacyError::channel(
+                                    "webcam listener closed unexpectedly",
+                                ));
                             }
                         }
                     }
                 };
 
-                State::Active((pipewire, webcam))
-            }
-            State::Error => {
-                error!("Privacy service error");
-
-                let _ = pending::<u8>().next().await;
-                State::Error
+                Ok(State::Active { pipewire, webcam })
             }
         }
+    }
+
+    #[cfg(test)]
+    async fn start_listening_with<P, PFut, W, WFut>(
+        state: State,
+        output: &mut Sender<ServiceEvent<Self>>,
+        pipewire_factory: P,
+        webcam_factory: W,
+    ) -> Result<State, PrivacyError>
+    where
+        P: FnMut() -> PFut,
+        PFut: Future<Output = Result<UnboundedReceiver<PrivacyEvent>, PrivacyError>> + Send,
+        W: FnMut() -> WFut,
+        WFut: Future<Output = Result<PrivacyStream, PrivacyError>> + Send,
+    {
+        Self::start_listening_with_factories(state, output, pipewire_factory, webcam_factory).await
     }
 }
 
 enum State {
     Init,
-    Active(
-        (
-            UnboundedReceiver<PrivacyEvent>,
-            Box<dyn Stream<Item = PrivacyEvent> + Unpin + Send>,
-        ),
-    ),
-    Error,
+    Active {
+        pipewire: UnboundedReceiver<PrivacyEvent>,
+        webcam: PrivacyStream,
+    },
 }
 
+/// Event emitted by the privacy service listeners.
 #[derive(Debug, Clone)]
 pub enum PrivacyEvent {
+    /// A new PipeWire node has been announced.
     AddNode(ApplicationNode),
+    /// A PipeWire node has been removed.
     RemoveNode(u32),
+    /// The webcam device has been opened by an application.
     WebcamOpen,
+    /// The webcam device has been closed by an application.
     WebcamClose,
 }
 
 impl ReadOnlyService for PrivacyService {
     type UpdateEvent = PrivacyEvent;
-    type Error = ();
+    type Error = PrivacyError;
 
     fn update(&mut self, event: Self::UpdateEvent) {
         match event {
@@ -275,7 +407,23 @@ impl ReadOnlyService for PrivacyService {
                 let mut state = State::Init;
 
                 loop {
-                    state = PrivacyService::start_listening(state, &mut output).await;
+                    match PrivacyService::start_listening(state, &mut output).await {
+                        Ok(next_state) => {
+                            state = next_state;
+                        }
+                        Err(error) => {
+                            if output
+                                .send(ServiceEvent::Error(error.clone()))
+                                .await
+                                .is_err()
+                            {
+                                warn!("Failed to emit privacy service error event");
+                                break;
+                            }
+
+                            state = State::Init;
+                        }
+                    }
                 }
             }),
         )
@@ -307,4 +455,117 @@ fn is_device_in_use(target: &str) -> i32 {
     }
 
     used_by
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{PrivacyEvent, PrivacyService, ServiceEvent, State, error::PrivacyError};
+    use iced::futures::{StreamExt, channel::mpsc, stream::pending};
+    use tokio::sync::mpsc::unbounded_channel;
+
+    #[tokio::test]
+    async fn init_succeeds_with_all_listeners() {
+        let (pipewire_tx, pipewire_rx) = unbounded_channel();
+        drop(pipewire_tx);
+        let mut pipewire_rx = Some(pipewire_rx);
+        let pipewire_factory = move || {
+            let receiver = pipewire_rx
+                .take()
+                .expect("pipewire factory should only be called once");
+            async move { Ok(receiver) }
+        };
+
+        let mut webcam_stream = Some(pending::<PrivacyEvent>().boxed());
+        let webcam_factory = move || {
+            let stream = webcam_stream
+                .take()
+                .expect("webcam factory should only be called once");
+            async move { Ok(stream) }
+        };
+
+        let (mut output_tx, mut output_rx) = mpsc::channel(10);
+        let state = State::Init;
+        let state = PrivacyService::start_listening_with(
+            state,
+            &mut output_tx,
+            pipewire_factory,
+            webcam_factory,
+        )
+        .await
+        .expect("initialisation should succeed");
+
+        assert!(matches!(state, State::Active { .. }));
+        let event = output_rx.next().await;
+        assert!(matches!(event, Some(ServiceEvent::Init(_))));
+    }
+
+    #[tokio::test]
+    async fn init_reports_pipewire_failure() {
+        let pipewire_factory = || async { Err(PrivacyError::pipewire_mainloop("boom")) };
+        let webcam_factory = || async { Ok(pending::<PrivacyEvent>().boxed()) };
+        let (mut output_tx, _output_rx) = mpsc::channel(1);
+
+        let result = PrivacyService::start_listening_with(
+            State::Init,
+            &mut output_tx,
+            pipewire_factory,
+            webcam_factory,
+        )
+        .await;
+        assert!(matches!(result, Err(PrivacyError::PipewireMainloop { .. })));
+    }
+
+    #[tokio::test]
+    async fn init_falls_back_when_webcam_missing() {
+        let (pipewire_tx, pipewire_rx) = unbounded_channel();
+        drop(pipewire_tx);
+        let mut pipewire_rx = Some(pipewire_rx);
+        let pipewire_factory = move || {
+            let receiver = pipewire_rx
+                .take()
+                .expect("pipewire factory should only be called once");
+            async move { Ok(receiver) }
+        };
+
+        let webcam_factory = || async { Err(PrivacyError::WebcamUnavailable) };
+        let (mut output_tx, mut output_rx) = mpsc::channel(2);
+        let state = PrivacyService::start_listening_with(
+            State::Init,
+            &mut output_tx,
+            pipewire_factory,
+            webcam_factory,
+        )
+        .await
+        .expect("initialisation should succeed with webcam fallback");
+
+        assert!(matches!(state, State::Active { .. }));
+        let event = output_rx.next().await;
+        assert!(matches!(event, Some(ServiceEvent::Init(_))));
+    }
+
+    #[tokio::test]
+    async fn init_fails_when_output_channel_closed() {
+        let (pipewire_tx, pipewire_rx) = unbounded_channel();
+        drop(pipewire_tx);
+        let mut pipewire_rx = Some(pipewire_rx);
+        let pipewire_factory = move || {
+            let receiver = pipewire_rx
+                .take()
+                .expect("pipewire factory should only be called once");
+            async move { Ok(receiver) }
+        };
+
+        let webcam_factory = || async { Ok(pending::<PrivacyEvent>().boxed()) };
+        let (mut output_tx, output_rx) = mpsc::channel::<ServiceEvent<PrivacyService>>(1);
+        drop(output_rx);
+
+        let result = PrivacyService::start_listening_with(
+            State::Init,
+            &mut output_tx,
+            pipewire_factory,
+            webcam_factory,
+        )
+        .await;
+        assert!(matches!(result, Err(PrivacyError::Channel { .. })));
+    }
 }

--- a/src/services/privacy/error.rs
+++ b/src/services/privacy/error.rs
@@ -1,0 +1,129 @@
+use std::sync::Arc;
+
+use masterror::Error;
+
+/// Error type emitted by the privacy service.
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum PrivacyError {
+    /// Failed to initialise the PipeWire main loop.
+    #[error("failed to initialise PipeWire main loop: {context}")]
+    PipewireMainloop { context: Arc<str> },
+
+    /// Failed to create the PipeWire context that owns the registry connection.
+    #[error("failed to create PipeWire context: {context}")]
+    PipewireContext { context: Arc<str> },
+
+    /// Failed to connect to the PipeWire core service.
+    #[error("failed to connect to PipeWire core: {context}")]
+    PipewireCore { context: Arc<str> },
+
+    /// Failed to access the PipeWire registry.
+    #[error("failed to access PipeWire registry: {context}")]
+    PipewireRegistry { context: Arc<str> },
+
+    /// Failed to initialise the inotify subsystem for webcam monitoring.
+    #[error("failed to initialise inotify: {context}")]
+    InotifyInit { context: Arc<str> },
+
+    /// Failed to register the webcam device with inotify.
+    #[error("failed to watch webcam device: {context}")]
+    InotifyWatch { context: Arc<str> },
+
+    /// Failed to communicate with the internal service channels.
+    #[error("privacy service channel error: {context}")]
+    Channel { context: Arc<str> },
+
+    /// The webcam device is not present on the system.
+    #[error("webcam device is unavailable")]
+    WebcamUnavailable,
+}
+
+impl PrivacyError {
+    fn arc_from(value: impl Into<String>) -> Arc<str> {
+        Arc::<str>::from(value.into())
+    }
+
+    /// Create a new PipeWire main loop error with additional context.
+    pub fn pipewire_mainloop(context: impl Into<String>) -> Self {
+        Self::PipewireMainloop {
+            context: Self::arc_from(context),
+        }
+    }
+
+    /// Create a new PipeWire context error with additional context.
+    pub fn pipewire_context(context: impl Into<String>) -> Self {
+        Self::PipewireContext {
+            context: Self::arc_from(context),
+        }
+    }
+
+    /// Create a new PipeWire core connection error with additional context.
+    pub fn pipewire_core(context: impl Into<String>) -> Self {
+        Self::PipewireCore {
+            context: Self::arc_from(context),
+        }
+    }
+
+    /// Create a new PipeWire registry error with additional context.
+    pub fn pipewire_registry(context: impl Into<String>) -> Self {
+        Self::PipewireRegistry {
+            context: Self::arc_from(context),
+        }
+    }
+
+    /// Create a new inotify initialisation error with additional context.
+    pub fn inotify_init(context: impl Into<String>) -> Self {
+        Self::InotifyInit {
+            context: Self::arc_from(context),
+        }
+    }
+
+    /// Create a new inotify watch registration error with additional context.
+    pub fn inotify_watch(context: impl Into<String>) -> Self {
+        Self::InotifyWatch {
+            context: Self::arc_from(context),
+        }
+    }
+
+    /// Create a new channel error with contextual information.
+    pub fn channel(context: impl Into<String>) -> Self {
+        Self::Channel {
+            context: Self::arc_from(context),
+        }
+    }
+}
+
+impl From<std::io::Error> for PrivacyError {
+    fn from(value: std::io::Error) -> Self {
+        match value.kind() {
+            std::io::ErrorKind::NotFound => PrivacyError::WebcamUnavailable,
+            _ => PrivacyError::inotify_init(value.to_string()),
+        }
+    }
+}
+
+impl From<pipewire::Error> for PrivacyError {
+    fn from(value: pipewire::Error) -> Self {
+        PrivacyError::pipewire_mainloop(value.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PrivacyError;
+
+    #[test]
+    fn converts_not_found_to_webcam_unavailable() {
+        let err = std::io::Error::new(std::io::ErrorKind::NotFound, "missing");
+        assert_eq!(PrivacyError::from(err), PrivacyError::WebcamUnavailable);
+    }
+
+    #[test]
+    fn converts_pipewire_error() {
+        let err = pipewire::Error::NoMemory;
+        assert!(matches!(
+            PrivacyError::from(err),
+            PrivacyError::PipewireMainloop { .. }
+        ));
+    }
+}


### PR DESCRIPTION
## Summary
- add a typed `PrivacyError` and wire it through the privacy service state machine, listeners, and UI consumer
- gracefully degrade when the webcam device is absent and surface initialization failures instead of panicking
- extend idle inhibitor tests and tighten brightness logging to satisfy clippy
- bump the crate version to 0.2.1 and document the release

## Testing
- cargo +nightly fmt --
- cargo +nightly clippy -- -D warnings
- cargo +nightly test --all
- cargo +nightly build --all-targets
- cargo +nightly doc --no-deps
- cargo audit
- cargo deny check *(fails: advisory-db fetch blocked in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d60b0b1250832baf75e1b928464973