### PR TITLE
Improve custom module error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add custom commands for power menu actions
 - Add battery module with configurable power-profile indicator and fallback view
 
+## [0.2.3] - 2025-09-26
+
+### Changed
+
+- Replace `unwrap`/`expect` usage in the custom module listener with structured error
+  handling and graceful shutdown semantics.
+- Surface command failures to the UI via `ServiceEvent::Error` so custom modules can
+  react to listener issues.
+- Switch stdout processing to `next_line().await?` with explicit channel-closure
+  handling to avoid panics.
+
+### Added
+
+- Unit test covering early process termination and closed channel scenarios for the
+  custom module runtime.
+
 ### Changed
 
 - Move "truncate_title_after_length" to the window_title configuration

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,7 +179,7 @@ dependencies = [
 
 [[package]]
 name = "android-properties"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7eb209b1518d6bb87b283c20095f5228ecda460da70b44f0802523dea6da04"
 
@@ -2288,6 +2288,7 @@ dependencies = [
  "serde_with",
  "shellexpand",
  "sysinfo",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
  "toml 0.9.7",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "hydebar"
 description = "A ready to go Wayland status bar for Hyprland"
 homepage = "https://github.com/MalpenZibo/hydebar"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2024"
 rust-version = "1.90"
 
@@ -47,3 +47,4 @@ clap = { version = "4", features = ["derive"] }
 shellexpand = { version = "3", features = ["path"] }
 inotify = "0.11"
 masterror = "0.21"
+thiserror = "1"


### PR DESCRIPTION
## Summary
- replace panic-driven error handling in the custom module listener with structured errors surfaced to the UI
- read listener stdout via `next_line().await?`, detecting closed channels and logging failures without panicking
- add regression coverage for early process termination and closed output channels, and bump the crate version with changelog notes

## Testing
- `cargo +nightly fmt --`
- `cargo +1.90.0 clippy -- -D warnings` *(fails: `pipewire::main_loop::MainLoop::new` unavailable with system PipeWire headers; see chunk 008c39)*
- `cargo audit`


------
https://chatgpt.com/codex/tasks/task_e_68d6256c06a0832bb000b80d20c1ce78