### PR TITLE
Improve network backend resilience

### DIFF
--- a/src/services/network/iwd_dbus/mod.rs
+++ b/src/services/network/iwd_dbus/mod.rs
@@ -105,6 +105,7 @@ impl super::NetworkBackend for IwdDbus<'_> {
             wireless_access_points,
             known_connections,
             scanning_nearby_wifi: is_scanning,
+            last_error: None,
         })
     }
 


### PR DESCRIPTION
## Summary
- share the existing NetworkManager proxies inside `subscribe_events` so that closures reuse them, propagate errors with `anyhow::Result`, and add the missing `last_error` field to cached network data
- introduce `NetworkServiceError`, add a reusable helper to consume result-bearing event streams, and restart the service after reporting failures via `ServiceEvent::Error`
- cover the new behaviour with async tests that emulate a failing stream and ensure the error state returns to initialization

## Testing
- `cargo +nightly fmt --`
- `cargo clippy -- -D warnings` *(fails: crates.io no longer provides `android-properties` v0.2.3 required by locked `winit` stack)*
- `cargo build --all-targets` *(fails: crates.io no longer provides `android-properties` v0.2.3 required by locked `winit` stack)*
- `cargo test --all` *(fails: crates.io no longer provides `android-properties` v0.2.3 required by locked `winit` stack)*
- `cargo doc --no-deps` *(fails: crates.io no longer provides `android-properties` v0.2.3 required by locked `winit` stack)*
- `cargo audit` *(installation aborted after prolonged compilation of dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d62d07ac1c832b9959057c47a69de0