### PR TITLE
Add event bus with coalescing queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add custom commands for power menu actions
 - Add battery module with configurable power-profile indicator and fallback view
 
+## [0.3.4] - 2025-09-27
+
+### Added
+
+- Introduced a bounded UI event bus with redraw/popup coalescing to reduce redundant work per frame.
+
 ## [0.3.3] - 2025-09-26
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2265,7 +2265,7 @@ dependencies = [
 
 [[package]]
 name = "hydebar-app"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "clap",
  "flexi_logger",
@@ -2279,7 +2279,7 @@ dependencies = [
 
 [[package]]
 name = "hydebar-core"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2314,7 +2314,7 @@ dependencies = [
 
 [[package]]
 name = "hydebar-gui"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "flexi_logger",
  "hydebar-core",
@@ -2326,7 +2326,7 @@ dependencies = [
 
 [[package]]
 name = "hydebar-proto"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "hex_color",
  "iced",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.3.3"
+version = "0.3.4"
 edition = "2024"
 rust-version = "1.90"
 

--- a/crates/hydebar-core/src/event_bus.rs
+++ b/crates/hydebar-core/src/event_bus.rs
@@ -1,0 +1,383 @@
+use std::collections::VecDeque;
+use std::num::NonZeroUsize;
+use std::sync::{Arc, Mutex};
+
+use thiserror::Error;
+
+/// High-level events emitted by the core to drive UI updates.
+///
+/// The enum is marked as `#[non_exhaustive]` to allow additional
+/// variants without breaking downstream consumers.
+///
+/// # Examples
+///
+/// ```
+/// # use hydebar_core::event_bus::BusEvent;
+/// let event = BusEvent::Redraw;
+/// assert!(matches!(event, BusEvent::Redraw));
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum BusEvent {
+    /// Request a redraw of the main surface.
+    Redraw,
+    /// Toggle the visibility of the popup menu for the active output.
+    PopupToggle,
+    /// Module-level events that do not fall into the built-in categories.
+    Module(ModuleEvent),
+}
+
+impl BusEvent {
+    fn is_coalescable_with(&self, other: &Self) -> bool {
+        matches!(
+            (self, other),
+            (BusEvent::Redraw, BusEvent::Redraw) | (BusEvent::PopupToggle, BusEvent::PopupToggle)
+        )
+    }
+}
+
+/// Events originating from individual modules.
+///
+/// # Examples
+///
+/// ```
+/// # use hydebar_core::event_bus::ModuleEvent;
+/// let event = ModuleEvent::Refresh;
+/// assert!(matches!(event, ModuleEvent::Refresh));
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ModuleEvent {
+    /// Indicates that a module requires a fresh data fetch.
+    Refresh,
+}
+
+#[derive(Debug)]
+struct EventBusInner {
+    queue: Mutex<VecDeque<BusEvent>>,
+    capacity: usize,
+}
+
+impl EventBusInner {
+    fn new(capacity: NonZeroUsize) -> Self {
+        Self {
+            queue: Mutex::new(VecDeque::with_capacity(capacity.get())),
+            capacity: capacity.get(),
+        }
+    }
+}
+
+/// Error returned when interacting with the [`EventBus`].
+///
+/// # Examples
+///
+/// ```
+/// # use hydebar_core::event_bus::EventBusError;
+/// let error = EventBusError::QueueFull { capacity: 4 };
+/// assert!(matches!(error, EventBusError::QueueFull { .. }));
+/// ```
+#[derive(Debug, Error)]
+pub enum EventBusError {
+    /// The queue reached its configured capacity.
+    #[error("event queue is full (capacity: {capacity})")]
+    QueueFull { capacity: usize },
+    /// The queue mutex was poisoned by a panic in another thread.
+    #[error("event queue state is poisoned")]
+    Poisoned,
+}
+
+/// In-memory queue that coalesces redraw-heavy events between dispatch cycles.
+///
+/// # Preconditions
+///
+/// - `capacity` passed to [`EventBus::new`] must be greater than zero.
+///
+/// # Postconditions
+///
+/// - The queue starts empty with enough capacity for `capacity` events.
+///
+/// # Examples
+///
+/// ```
+/// # use hydebar_core::event_bus::{BusEvent, EventBus};
+/// # use std::num::NonZeroUsize;
+/// let bus = EventBus::new(NonZeroUsize::new(8).expect("non-zero"));
+/// let sender = bus.sender();
+/// let mut receiver = bus.receiver();
+/// sender.try_send(BusEvent::Redraw).expect("send");
+/// assert_eq!(receiver.try_recv().expect("receive"), Some(BusEvent::Redraw));
+/// ```
+#[derive(Debug, Clone)]
+pub struct EventBus {
+    inner: Arc<EventBusInner>,
+}
+
+impl EventBus {
+    /// Construct a bus with the provided capacity.
+    ///
+    /// # Preconditions
+    ///
+    /// - `capacity` must be non-zero.
+    ///
+    /// # Postconditions
+    ///
+    /// - Returns a bus with an empty queue sized for `capacity` items.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use hydebar_core::event_bus::{BusEvent, EventBus};
+    /// # use std::num::NonZeroUsize;
+    /// let bus = EventBus::new(NonZeroUsize::new(4).expect("capacity"));
+    /// let sender = bus.sender();
+    /// sender.try_send(BusEvent::Redraw).expect("send");
+    /// ```
+    pub fn new(capacity: NonZeroUsize) -> Self {
+        Self {
+            inner: Arc::new(EventBusInner::new(capacity)),
+        }
+    }
+
+    /// Acquire a sender handle tied to the bus.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use hydebar_core::event_bus::{BusEvent, EventBus};
+    /// # use std::num::NonZeroUsize;
+    /// let bus = EventBus::new(NonZeroUsize::new(4).expect("capacity"));
+    /// let sender = bus.sender();
+    /// sender.try_send(BusEvent::Redraw).expect("send");
+    /// ```
+    pub fn sender(&self) -> EventSender {
+        EventSender {
+            inner: Arc::clone(&self.inner),
+        }
+    }
+
+    /// Acquire a receiver handle tied to the bus.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use hydebar_core::event_bus::{BusEvent, EventBus};
+    /// # use std::num::NonZeroUsize;
+    /// let bus = EventBus::new(NonZeroUsize::new(4).expect("capacity"));
+    /// let mut receiver = bus.receiver();
+    /// assert_eq!(receiver.try_recv().expect("empty"), None);
+    /// ```
+    pub fn receiver(&self) -> EventReceiver {
+        EventReceiver {
+            inner: Arc::clone(&self.inner),
+        }
+    }
+}
+
+/// Handle used to enqueue events.
+///
+/// # Examples
+///
+/// ```
+/// # use hydebar_core::event_bus::{BusEvent, EventBus};
+/// # use std::num::NonZeroUsize;
+/// let bus = EventBus::new(NonZeroUsize::new(2).expect("capacity"));
+/// let sender = bus.sender();
+/// sender.try_send(BusEvent::Redraw).expect("send");
+/// ```
+#[derive(Debug, Clone)]
+pub struct EventSender {
+    inner: Arc<EventBusInner>,
+}
+
+impl EventSender {
+    /// Attempt to enqueue a new event.
+    ///
+    /// # Preconditions
+    ///
+    /// - The underlying queue must not already be at capacity.
+    ///
+    /// # Postconditions
+    ///
+    /// - Enqueues `event` unless it is coalesced with an existing [`BusEvent::Redraw`]
+    ///   or [`BusEvent::PopupToggle`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use hydebar_core::event_bus::{BusEvent, EventBus};
+    /// # use std::num::NonZeroUsize;
+    /// let bus = EventBus::new(NonZeroUsize::new(2).expect("capacity"));
+    /// let sender = bus.sender();
+    /// sender.try_send(BusEvent::Redraw).expect("send");
+    /// ```
+    pub fn try_send(&self, event: BusEvent) -> Result<(), EventBusError> {
+        let mut queue = self
+            .inner
+            .queue
+            .lock()
+            .map_err(|_| EventBusError::Poisoned)?;
+
+        if let Some(last) = queue.back() {
+            if last.is_coalescable_with(&event) {
+                return Ok(());
+            }
+        }
+
+        if queue.len() >= self.inner.capacity {
+            return Err(EventBusError::QueueFull {
+                capacity: self.inner.capacity,
+            });
+        }
+
+        queue.push_back(event);
+        Ok(())
+    }
+}
+
+/// Handle used to drain events in FIFO order.
+///
+/// # Examples
+///
+/// ```
+/// # use hydebar_core::event_bus::{BusEvent, EventBus};
+/// # use std::num::NonZeroUsize;
+/// let bus = EventBus::new(NonZeroUsize::new(2).expect("capacity"));
+/// let sender = bus.sender();
+/// let mut receiver = bus.receiver();
+/// sender.try_send(BusEvent::Redraw).expect("send");
+/// assert_eq!(receiver.try_recv().expect("receive"), Some(BusEvent::Redraw));
+/// ```
+#[derive(Debug)]
+pub struct EventReceiver {
+    inner: Arc<EventBusInner>,
+}
+
+impl EventReceiver {
+    /// Attempt to fetch the next event, returning `None` if the queue is empty.
+    ///
+    /// # Postconditions
+    ///
+    /// - Removes and returns the front event if one exists.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use hydebar_core::event_bus::{BusEvent, EventBus};
+    /// # use std::num::NonZeroUsize;
+    /// let bus = EventBus::new(NonZeroUsize::new(1).expect("capacity"));
+    /// let sender = bus.sender();
+    /// let mut receiver = bus.receiver();
+    /// sender.try_send(BusEvent::Redraw).expect("send");
+    /// assert_eq!(receiver.try_recv().expect("receive"), Some(BusEvent::Redraw));
+    /// ```
+    pub fn try_recv(&mut self) -> Result<Option<BusEvent>, EventBusError> {
+        let mut queue = self
+            .inner
+            .queue
+            .lock()
+            .map_err(|_| EventBusError::Poisoned)?;
+        Ok(queue.pop_front())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn coalesces_consecutive_redraw_events() {
+        let bus = EventBus::new(NonZeroUsize::new(4).expect("capacity"));
+        let sender = bus.sender();
+        let mut receiver = bus.receiver();
+
+        sender.try_send(BusEvent::Redraw).expect("first send");
+        sender.try_send(BusEvent::Redraw).expect("coalesced send");
+
+        assert_eq!(
+            receiver.try_recv().expect("receive"),
+            Some(BusEvent::Redraw)
+        );
+        assert_eq!(receiver.try_recv().expect("empty"), None);
+    }
+
+    #[test]
+    fn coalesces_consecutive_popup_toggle_events() {
+        let bus = EventBus::new(NonZeroUsize::new(4).expect("capacity"));
+        let sender = bus.sender();
+        let mut receiver = bus.receiver();
+
+        sender.try_send(BusEvent::PopupToggle).expect("first send");
+        sender
+            .try_send(BusEvent::PopupToggle)
+            .expect("coalesced send");
+
+        assert_eq!(
+            receiver.try_recv().expect("receive"),
+            Some(BusEvent::PopupToggle)
+        );
+        assert_eq!(receiver.try_recv().expect("empty"), None);
+    }
+
+    #[test]
+    fn preserves_non_coalescable_ordering() {
+        let bus = EventBus::new(NonZeroUsize::new(8).expect("capacity"));
+        let sender = bus.sender();
+        let mut receiver = bus.receiver();
+
+        sender.try_send(BusEvent::Redraw).expect("send redraw");
+        sender
+            .try_send(BusEvent::Module(ModuleEvent::Refresh))
+            .expect("send module");
+        sender.try_send(BusEvent::Redraw).expect("send redraw");
+        sender.try_send(BusEvent::PopupToggle).expect("send popup");
+        sender
+            .try_send(BusEvent::PopupToggle)
+            .expect("coalesced popup");
+
+        assert_eq!(
+            receiver.try_recv().expect("receive"),
+            Some(BusEvent::Redraw)
+        );
+        assert_eq!(
+            receiver.try_recv().expect("receive"),
+            Some(BusEvent::Module(ModuleEvent::Refresh))
+        );
+        assert_eq!(
+            receiver.try_recv().expect("receive"),
+            Some(BusEvent::Redraw)
+        );
+        assert_eq!(
+            receiver.try_recv().expect("receive"),
+            Some(BusEvent::PopupToggle)
+        );
+        assert_eq!(receiver.try_recv().expect("empty"), None);
+    }
+
+    #[test]
+    fn respects_bounded_capacity() {
+        let bus = EventBus::new(NonZeroUsize::new(2).expect("capacity"));
+        let sender = bus.sender();
+        let mut receiver = bus.receiver();
+
+        sender.try_send(BusEvent::Redraw).expect("first event");
+        sender
+            .try_send(BusEvent::Module(ModuleEvent::Refresh))
+            .expect("second event");
+
+        let overflow = sender.try_send(BusEvent::PopupToggle);
+        assert!(matches!(
+            overflow,
+            Err(EventBusError::QueueFull { capacity: 2 })
+        ));
+
+        assert_eq!(
+            receiver.try_recv().expect("receive"),
+            Some(BusEvent::Redraw)
+        );
+        assert_eq!(
+            receiver.try_recv().expect("receive"),
+            Some(BusEvent::Module(ModuleEvent::Refresh))
+        );
+        assert_eq!(receiver.try_recv().expect("empty"), None);
+    }
+}

--- a/crates/hydebar-core/src/lib.rs
+++ b/crates/hydebar-core/src/lib.rs
@@ -1,8 +1,11 @@
+/// Default height of the main status bar in logical pixels.
 pub const HEIGHT: f64 = 34.;
 
 pub mod adapters;
 pub mod components;
 pub mod config;
+/// Event bus primitives for communicating UI updates across the core.
+pub mod event_bus;
 pub mod menu;
 pub mod modules;
 pub mod outputs;


### PR DESCRIPTION
## Summary
- add a documented UI event bus with a bounded queue and coalescing sender/receiver handles
- cover redraw/popup coalescing and overflow conditions with focused unit tests
- expose the new API, bump the workspace version to 0.3.4, and document the change in the changelog

## Testing
- cargo +nightly fmt --
- cargo +1.90.0 clippy -- -D warnings
- cargo +1.90.0 build --all-targets *(fails: missing system library `xkbcommon` required by smithay-client-toolkit build script)*
- cargo +1.90.0 test --all *(fails: missing system library `xkbcommon` required by smithay-client-toolkit build script)*
- cargo audit
- cargo deny check *(fails: network error fetching RustSec advisory database)*

------
https://chatgpt.com/codex/tasks/task_e_68d692c1ad9c832b864878dd0fe38bf2