### PR TITLE
Re-export module context types

### DIFF
--- a/crates/hydebar-core/src/lib.rs
+++ b/crates/hydebar-core/src/lib.rs
@@ -17,3 +17,5 @@ pub mod style;
 #[cfg(test)]
 pub mod test_utils;
 pub mod utils;
+
+pub use module_context::{ModuleContext, ModuleEventSender};


### PR DESCRIPTION
## Summary
- re-export `ModuleContext` and `ModuleEventSender` from the crate root for convenient downstream imports

## Testing
- cargo +nightly fmt --
- cargo clippy -- -D warnings *(fails: missing system dependency `xkbcommon` required by `smithay-client-toolkit` build script)*
- cargo build --all-targets *(fails: missing system dependency `xkbcommon` required by `smithay-client-toolkit` build script)*
- cargo test --all *(fails: missing system dependency `xkbcommon` required by `smithay-client-toolkit` build script)*
- cargo doc --no-deps *(fails: missing system dependency `xkbcommon` required by `smithay-client-toolkit` build script)*

------
https://chatgpt.com/codex/tasks/task_e_68d757826248832b8a5de78908487038