### PR TITLE
Refactor tray module event handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.2] - 2025-09-27
+
+### Changed
+
+- Move the tray module onto runtime-spawned listeners using typed module event
+  senders, removing the iced subscription bridge and wiring command dispatch
+  through the shared runtime.  
+  (Refactors command execution to publish feedback via the module event bus.)
+
+### Added
+
+- Regression tests ensuring tray listener tasks are aborted on re-registration
+  and that menu commands surface updates through the event bus.
+
 ## [0.5.1] - 2025-09-27
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2265,7 +2265,7 @@ dependencies = [
 
 [[package]]
 name = "hydebar-app"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "clap",
  "flexi_logger",
@@ -2279,7 +2279,7 @@ dependencies = [
 
 [[package]]
 name = "hydebar-core"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2314,7 +2314,7 @@ dependencies = [
 
 [[package]]
 name = "hydebar-gui"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "flexi_logger",
  "hydebar-core",
@@ -2326,7 +2326,7 @@ dependencies = [
 
 [[package]]
 name = "hydebar-proto"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "hex_color",
  "iced",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.5.1"
+version = "0.5.2"
 edition = "2024"
 rust-version = "1.90"
 

--- a/crates/hydebar-core/src/modules/tray.rs
+++ b/crates/hydebar-core/src/modules/tray.rs
@@ -1,7 +1,13 @@
-use super::{Module, OnModulePress};
+use std::{future::Future, pin::Pin, sync::Arc};
+
+use log::{debug, error, warn};
+use tokio::{runtime::Handle, task::JoinHandle};
+
+use super::{Module, ModuleError, OnModulePress};
 use crate::{
-    app,
+    ModuleContext, ModuleEventSender, app,
     components::icons::{Icons, icon},
+    event_bus::ModuleEvent,
     menu::MenuType,
     position_button::position_button,
     services::{
@@ -14,11 +20,10 @@ use crate::{
     style::ghost_button_style,
 };
 use iced::{
-    Alignment, Element, Length, Subscription, Task,
+    Alignment, Element, Length, Task,
     widget::{Column, Image, Row, Svg, button, horizontal_rule, row, text, toggler},
     window::Id,
 };
-use log::debug;
 
 #[derive(Debug, Clone)]
 pub enum TrayMessage {
@@ -27,13 +32,62 @@ pub enum TrayMessage {
     MenuSelected(String, i32),
 }
 
-#[derive(Debug, Default, Clone)]
+type ListenerSpawner =
+    Arc<dyn Fn(ModuleEventSender<TrayMessage>, Handle) -> JoinHandle<()> + Send + Sync>;
+type CommandFactory =
+    Arc<dyn Fn(Option<&TrayService>, TrayCommand) -> Option<TrayCommandFuture> + Send + Sync>;
+type TrayCommandFuture = Pin<Box<dyn Future<Output = ServiceEvent<TrayService>> + Send + 'static>>;
+
+#[derive(Debug)]
 pub struct TrayModule {
     pub service: Option<TrayService>,
     pub submenus: Vec<i32>,
+    sender: Option<ModuleEventSender<TrayMessage>>,
+    runtime: Option<Handle>,
+    listener_handles: Vec<JoinHandle<()>>,
+    listener_spawner: ListenerSpawner,
+    command_factory: CommandFactory,
 }
 
 impl TrayModule {
+    fn abort_listener_handles(&mut self) {
+        for handle in self.listener_handles.drain(..) {
+            handle.abort();
+        }
+    }
+
+    fn spawn_listener(&mut self) {
+        let Some(sender) = self.sender.clone() else {
+            warn!("tray module missing event sender; skipping listener spawn");
+            return;
+        };
+        let Some(runtime) = self.runtime.clone() else {
+            warn!("tray module missing runtime handle; skipping listener spawn");
+            return;
+        };
+
+        let spawner = Arc::clone(&self.listener_spawner);
+        self.listener_handles.push(spawner(sender, runtime));
+    }
+
+    fn dispatch_command(&self, command_future: TrayCommandFuture) {
+        let Some(runtime) = self.runtime.clone() else {
+            warn!("tray module missing runtime handle; skipping command dispatch");
+            return;
+        };
+        let Some(sender) = self.sender.clone() else {
+            warn!("tray module missing event sender; skipping command dispatch");
+            return;
+        };
+
+        runtime.spawn(async move {
+            let event = command_future.await;
+            if let Err(err) = sender.try_send(TrayMessage::Event(Box::new(event))) {
+                error!("failed to publish tray command result: {err}");
+            }
+        });
+    }
+
     pub fn update(&mut self, message: TrayMessage) -> Task<crate::app::Message> {
         match message {
             TrayMessage::Event(event) => match *event {
@@ -57,15 +111,18 @@ impl TrayModule {
                 }
                 Task::none()
             }
-            TrayMessage::MenuSelected(name, id) => match self.service.as_mut() {
-                Some(service) => {
-                    debug!("Tray menu click: {id}");
-                    service
-                        .command(TrayCommand::MenuSelected(name, id))
-                        .map(|event| crate::app::Message::Tray(TrayMessage::Event(Box::new(event))))
+            TrayMessage::MenuSelected(name, id) => {
+                debug!("Tray menu click: {id}");
+
+                if let Some(command) = (self.command_factory)(
+                    self.service.as_ref(),
+                    TrayCommand::MenuSelected(name, id),
+                ) {
+                    self.dispatch_command(command);
                 }
-                _ => Task::none(),
-            },
+
+                Task::none()
+            }
         }
     }
 
@@ -160,6 +217,19 @@ impl Module for TrayModule {
     type ViewData<'a> = (Id, f32);
     type RegistrationData<'a> = ();
 
+    fn register(
+        &mut self,
+        ctx: &ModuleContext,
+        _: Self::RegistrationData<'_>,
+    ) -> Result<(), ModuleError> {
+        self.abort_listener_handles();
+        self.sender = Some(ctx.module_sender(ModuleEvent::Tray));
+        self.runtime = Some(ctx.runtime_handle().clone());
+        self.spawn_listener();
+
+        Ok(())
+    }
+
     fn view(
         &self,
         (id, opacity): Self::ViewData<'_>,
@@ -206,7 +276,214 @@ impl Module for TrayModule {
             })
     }
 
-    fn subscription(&self) -> Option<Subscription<app::Message>> {
-        Some(TrayService::subscribe().map(|e| app::Message::Tray(TrayMessage::Event(Box::new(e)))))
+    fn subscription(&self) -> Option<iced::Subscription<app::Message>> {
+        None
+    }
+}
+
+impl Default for TrayModule {
+    fn default() -> Self {
+        Self {
+            service: None,
+            submenus: Vec::new(),
+            sender: None,
+            runtime: None,
+            listener_handles: Vec::new(),
+            listener_spawner: default_listener_spawner(),
+            command_factory: default_command_factory(),
+        }
+    }
+}
+
+impl Drop for TrayModule {
+    fn drop(&mut self) {
+        self.abort_listener_handles();
+    }
+}
+
+fn default_listener_spawner() -> ListenerSpawner {
+    Arc::new(|sender, runtime| {
+        runtime.spawn(async move {
+            TrayService::start_listening(|event| {
+                let sender = sender.clone();
+                async move {
+                    if let Err(err) = sender.try_send(TrayMessage::Event(Box::new(event))) {
+                        error!("failed to publish tray service event: {err}");
+                    }
+                }
+            })
+            .await;
+        })
+    })
+}
+
+fn default_command_factory() -> CommandFactory {
+    Arc::new(|service, command| service.and_then(|svc| svc.prepare_command(command)))
+}
+
+#[cfg(test)]
+impl TrayModule {
+    fn with_factories(listener_spawner: ListenerSpawner, command_factory: CommandFactory) -> Self {
+        Self {
+            service: None,
+            submenus: Vec::new(),
+            sender: None,
+            runtime: None,
+            listener_handles: Vec::new(),
+            listener_spawner,
+            command_factory,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        num::NonZeroUsize,
+        sync::{Arc, Mutex},
+        time::Duration,
+    };
+
+    use iced::Task;
+    use tokio::{runtime::Handle, task::yield_now, time::timeout};
+
+    use crate::{
+        ModuleContext,
+        event_bus::{BusEvent, EventBus, ModuleEvent},
+        services::{
+            ServiceEvent,
+            tray::{TrayCommand, TrayEvent},
+        },
+    };
+
+    use super::{
+        CommandFactory, ListenerSpawner, TrayMessage, TrayModule, default_command_factory,
+        default_listener_spawner,
+    };
+
+    #[test]
+    fn aborts_existing_listener_on_reregistration() {
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .enable_all()
+            .build()
+            .expect("runtime");
+        let bus = EventBus::new(NonZeroUsize::new(4).expect("capacity"));
+        let context = ModuleContext::new(bus.sender(), runtime.handle().clone());
+
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        let cancellation = Arc::new(Mutex::new(Some(tx)));
+        let cancellation_spawner = Arc::clone(&cancellation);
+
+        let listener_spawner: ListenerSpawner = Arc::new(move |_, handle: Handle| {
+            let cancellation = Arc::clone(&cancellation_spawner);
+
+            handle.spawn(async move {
+                struct CancellationProbe {
+                    signal: Arc<Mutex<Option<tokio::sync::oneshot::Sender<()>>>>,
+                }
+
+                impl Drop for CancellationProbe {
+                    fn drop(&mut self) {
+                        if let Some(sender) = self.signal.lock().expect("cancellation lock").take()
+                        {
+                            let _ = sender.send(());
+                        }
+                    }
+                }
+
+                let _probe = CancellationProbe {
+                    signal: cancellation,
+                };
+                tokio::future::pending::<()>().await;
+            })
+        });
+
+        let mut module = TrayModule::with_factories(listener_spawner, default_command_factory());
+
+        module.register(&context, ()).expect("first registration");
+        module.register(&context, ()).expect("second registration");
+
+        runtime
+            .block_on(async {
+                timeout(Duration::from_millis(100), async {
+                    rx.await.expect("cancellation")
+                })
+                .await
+            })
+            .expect("listener aborted");
+    }
+
+    #[test]
+    fn publishes_command_results_via_event_bus() {
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .enable_all()
+            .build()
+            .expect("runtime");
+        let bus = EventBus::new(NonZeroUsize::new(4).expect("capacity"));
+        let sender = bus.sender();
+        let mut receiver = bus.receiver();
+        let context = ModuleContext::new(sender, runtime.handle().clone());
+
+        let listener_spawner: ListenerSpawner =
+            Arc::new(|_, handle: Handle| handle.spawn(async {}));
+        let command_factory: CommandFactory = Arc::new(|_, command| match command {
+            TrayCommand::MenuSelected(name, _) => {
+                let layout = super::Layout(
+                    1,
+                    super::LayoutProps {
+                        children_display: None,
+                        label: Some("Updated".into()),
+                        type_: None,
+                        toggle_type: None,
+                        toggle_state: None,
+                    },
+                    Vec::new(),
+                );
+
+                Some(Box::pin(async move {
+                    ServiceEvent::Update(TrayEvent::MenuLayoutChanged(name, layout))
+                }))
+            }
+        });
+
+        let mut module = TrayModule::with_factories(listener_spawner, command_factory);
+        module.register(&context, ()).expect("registration");
+
+        assert!(matches!(
+            module.update(TrayMessage::MenuSelected("tray".into(), 42)),
+            Task::None
+        ));
+
+        let event = runtime
+            .block_on(async {
+                timeout(Duration::from_millis(100), async {
+                    loop {
+                        if let Some(event) = receiver.try_recv().expect("bus read") {
+                            break event;
+                        }
+                        yield_now().await;
+                    }
+                })
+                .await
+            })
+            .expect("event published");
+
+        match event {
+            BusEvent::Module(ModuleEvent::Tray(TrayMessage::Event(event))) => match *event {
+                ServiceEvent::Update(TrayEvent::MenuLayoutChanged(ref name, _)) => {
+                    assert_eq!(name, "tray");
+                }
+                other => panic!("unexpected tray event: {other:?}"),
+            },
+            other => panic!("unexpected bus event: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn retains_default_listener_spawner() {
+        let _module =
+            TrayModule::with_factories(default_listener_spawner(), default_command_factory());
     }
 }


### PR DESCRIPTION
## Summary
- refactor the tray module to own runtime handles, spawn tray listeners, and forward events via the module bus
- update tray service helpers to expose async command futures and public menu execution helpers for runtime dispatch
- extend tray unit tests for listener cancellation and command feedback while bumping the workspace to version 0.5.2

## Testing
- cargo +nightly fmt --
- cargo clippy -- -D warnings *(fails: workspace now requires rustc 1.90 but container provides 1.89)*
- cargo build --all-targets *(fails: workspace now requires rustc 1.90 but container provides 1.89)*
- cargo test --all *(fails: workspace now requires rustc 1.90 but container provides 1.89)*
- cargo doc --no-deps *(fails: workspace now requires rustc 1.90 but container provides 1.89)*
- cargo audit *(reports unmaintained transitive crates derivative, instant, paste)*
- cargo deny check *(fails: cannot fetch GitHub advisory database)*

------
https://chatgpt.com/codex/tasks/task_e_68d7c0bee6d4832bbcca235cd3c96ee0