### PR TITLE
Refactor system info module polling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.4] - 2025-09-27
+
+### Changed
+
+- Move the system info module to a runtime-driven refresh loop powered by
+  `ModuleContext`, publishing updates through typed module senders instead of
+  iced subscriptions.
+
+### Added
+
+- Unit tests covering periodic refresh scheduling and task teardown to ensure
+  polling loops honour cancellation on re-registration.
+
 ## [0.5.3] - 2025-09-27
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2265,7 +2265,7 @@ dependencies = [
 
 [[package]]
 name = "hydebar-app"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "clap",
  "flexi_logger",
@@ -2279,7 +2279,7 @@ dependencies = [
 
 [[package]]
 name = "hydebar-core"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2314,7 +2314,7 @@ dependencies = [
 
 [[package]]
 name = "hydebar-gui"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "flexi_logger",
  "hydebar-core",
@@ -2326,7 +2326,7 @@ dependencies = [
 
 [[package]]
 name = "hydebar-proto"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "hex_color",
  "iced",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.5.3"
+version = "0.5.4"
 edition = "2024"
 rust-version = "1.90"
 

--- a/crates/hydebar-gui/src/app.rs
+++ b/crates/hydebar-gui/src/app.rs
@@ -525,7 +525,10 @@ impl App {
                 self.window_title.update(message, &self.config.window_title);
                 Task::none()
             }
-            Message::SystemInfo(message) => self.system_info.update(message),
+            Message::SystemInfo(message) => {
+                self.system_info.update(message);
+                Task::none()
+            }
             Message::KeyboardLayout(message) => {
                 self.keyboard_layout.update(message);
                 Task::none()


### PR DESCRIPTION
## Summary
- move the system info module to a runtime-driven refresh loop that publishes updates through the module event bus
- simplify the GUI bridge to treat system info updates as internal state refreshes instead of iced commands
- add regression tests, bump the crate version to 0.5.4, and document the change in the changelog

## Testing
- cargo +nightly fmt --
- cargo +1.90.0 clippy -- -D warnings *(fails: workspace does not compile due to pre-existing errors in hydebar-core and related crates)*

------
https://chatgpt.com/codex/tasks/task_e_68d7ddc46840832ba0a44ebb609acf34