### PR TITLE
Refactor media player module for runtime tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2025-09-27
+
+### Changed
+
+- Move the media player module onto runtime-spawned listeners driven by the
+  shared `ModuleContext`, caching the typed module sender and executing MPRIS
+  commands on the runtime while forwarding results through the event bus.
+- Expose asynchronous helpers from the MPRIS service that surface command
+  failures as `ModuleError` values, aligning service interactions with the
+  runtime-driven pattern.
+
+### Added
+
+- Regression tests covering media player command feedback and listener
+  cancellation to ensure command results reach the UI and background tasks are
+  aborted on re-registration.
+
 ## [0.5.4] - 2025-09-27
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2265,7 +2265,7 @@ dependencies = [
 
 [[package]]
 name = "hydebar-app"
-version = "0.5.4"
+version = "0.6.0"
 dependencies = [
  "clap",
  "flexi_logger",
@@ -2279,7 +2279,7 @@ dependencies = [
 
 [[package]]
 name = "hydebar-core"
-version = "0.5.4"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2314,7 +2314,7 @@ dependencies = [
 
 [[package]]
 name = "hydebar-gui"
-version = "0.5.4"
+version = "0.6.0"
 dependencies = [
  "flexi_logger",
  "hydebar-core",
@@ -2326,7 +2326,7 @@ dependencies = [
 
 [[package]]
 name = "hydebar-proto"
-version = "0.5.4"
+version = "0.6.0"
 dependencies = [
  "hex_color",
  "iced",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.5.4"
+version = "0.6.0"
 edition = "2024"
 rust-version = "1.90"
 

--- a/crates/hydebar-core/src/event_bus.rs
+++ b/crates/hydebar-core/src/event_bus.rs
@@ -97,7 +97,7 @@ impl EventBusInner {
 /// let error = EventBusError::QueueFull { capacity: 4 };
 /// assert!(matches!(error, EventBusError::QueueFull { .. }));
 /// ```
-#[derive(Debug, Error)]
+#[derive(Debug, Error, Clone)]
 pub enum EventBusError {
     /// The queue reached its configured capacity.
     #[error("event queue is full (capacity: {capacity})")]

--- a/crates/hydebar-core/src/modules.rs
+++ b/crates/hydebar-core/src/modules.rs
@@ -41,7 +41,7 @@ pub enum OnModulePress {
 }
 
 /// Errors that can occur while registering a module.
-#[derive(Debug, Error)]
+#[derive(Debug, Error, Clone)]
 pub enum ModuleError {
     /// Propagates failures originating from the event bus.
     #[error("module event bus interaction failed: {0}")]


### PR DESCRIPTION
## Summary
- cache the media player module sender/runtime handle and spawn listener tasks when registering
- expose async helpers from the MPRIS service to execute commands and publish events without iced subscriptions
- derive Clone for module and event bus errors, add targeted tests, and bump the workspace version to 0.6.0 with changelog updates

## Testing
- cargo +nightly fmt --
- cargo +1.90.0 build --all-targets *(fails: unresolved `crate::app` imports across hydebar-core and missing `futures` dependency wiring)*

------
https://chatgpt.com/codex/tasks/task_e_68d7e247175c832b8126bb83564bb58e