### PR TITLE
Refactor custom module listener to use runtime-managed tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1] - 2025-09-27
+
+### Changed
+
+- Run custom module listeners on the shared runtime handle, caching module
+  event senders from `ModuleContext` and aborting previous tasks when
+  re-registering definitions.
+- Publish custom module updates through `ModuleEvent::Custom` conversions,
+  replacing the iced channel bridge and surfacing bus failures as `ModuleError`
+  values.
+
+### Added
+
+- Unit tests covering error propagation from the custom module listener and
+  validating that runtime-spawned tasks shut down cleanly on configuration
+  changes.
+
 ## [0.6.0] - 2025-09-27
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2265,7 +2265,7 @@ dependencies = [
 
 [[package]]
 name = "hydebar-app"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "clap",
  "flexi_logger",
@@ -2279,7 +2279,7 @@ dependencies = [
 
 [[package]]
 name = "hydebar-core"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2314,7 +2314,7 @@ dependencies = [
 
 [[package]]
 name = "hydebar-gui"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "flexi_logger",
  "hydebar-core",
@@ -2326,7 +2326,7 @@ dependencies = [
 
 [[package]]
 name = "hydebar-proto"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "hex_color",
  "iced",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 rust-version = "1.90"
 

--- a/crates/hydebar-core/src/modules/custom_module/tests.rs
+++ b/crates/hydebar-core/src/modules/custom_module/tests.rs
@@ -1,0 +1,185 @@
+use super::*;
+use crate::event_bus::{BusEvent, EventBus};
+use std::{num::NonZeroUsize, sync::Arc, time::Duration};
+use tokio::{
+    io::{self, AsyncWriteExt, BufReader},
+    time::{sleep, timeout},
+};
+
+#[tokio::test]
+async fn send_event_propagates_module_errors() {
+    let bus = EventBus::new(NonZeroUsize::new(1).expect("non-zero"));
+    let context = ModuleContext::new(bus.sender(), tokio::runtime::Handle::current());
+    let module_name: Arc<str> = Arc::from("custom");
+    let sender = context.module_sender({
+        let module_name = Arc::clone(&module_name);
+        move |message| ModuleEvent::Custom {
+            name: Arc::clone(&module_name),
+            message,
+        }
+    });
+
+    let data = CustomListenData {
+        alt: String::from("alt"),
+        text: None,
+    };
+
+    sender
+        .try_send(Message::Event(ServiceEvent::Update(data.clone())))
+        .expect("initial send");
+
+    let result = send_event(&sender, ServiceEvent::Update(data));
+    assert!(matches!(result, Err(ModuleError::EventBus(_))));
+}
+
+#[tokio::test]
+async fn forward_custom_updates_delivers_events_and_errors() {
+    let bus = EventBus::new(NonZeroUsize::new(8).expect("non-zero"));
+    let context = ModuleContext::new(bus.sender(), tokio::runtime::Handle::current());
+    let module_name: Arc<str> = Arc::from("custom");
+    let sender = context.module_sender({
+        let module_name = Arc::clone(&module_name);
+        move |message| ModuleEvent::Custom {
+            name: Arc::clone(&module_name),
+            message,
+        }
+    });
+
+    let (mut writer, reader) = io::duplex(256);
+    writer
+        .write_all(
+            br#"{"alt":"value","text":"ok"}
+invalid
+"#,
+        )
+        .await
+        .expect("write output");
+    writer.shutdown().await.expect("shutdown writer");
+
+    let mut lines = BufReader::new(reader).lines();
+    forward_custom_updates(&mut lines, module_name.as_ref(), &sender)
+        .await
+        .expect("forward updates");
+
+    let mut receiver = bus.receiver();
+
+    let first = receiver
+        .try_recv()
+        .expect("first event")
+        .expect("event present");
+    match first {
+        BusEvent::Module(ModuleEvent::Custom { name, message }) => {
+            assert_eq!(name.as_ref(), "custom");
+            match message {
+                Message::Event(ServiceEvent::Update(data)) => {
+                    assert_eq!(data.alt, "value");
+                    assert_eq!(data.text.as_deref(), Some("ok"));
+                }
+                other => panic!("unexpected message: {other:?}"),
+            }
+        }
+        other => panic!("unexpected event: {other:?}"),
+    }
+
+    let second = receiver
+        .try_recv()
+        .expect("second event")
+        .expect("event present");
+    match second {
+        BusEvent::Module(ModuleEvent::Custom { name, message }) => {
+            assert_eq!(name.as_ref(), "custom");
+            match message {
+                Message::Event(ServiceEvent::Error(error)) => {
+                    assert!(matches!(error, CustomCommandError::Parse(_, _)));
+                }
+                other => panic!("unexpected message: {other:?}"),
+            }
+        }
+        other => panic!("unexpected event: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn re_register_aborts_previous_listener() {
+    let bus = EventBus::new(NonZeroUsize::new(32).expect("non-zero"));
+    let context = ModuleContext::new(bus.sender(), tokio::runtime::Handle::current());
+    let mut custom = Custom::default();
+
+    let mut receiver = bus.receiver();
+
+    let first = CustomModuleDef {
+        name: String::from("first"),
+        command: String::from("true"),
+        icon: None,
+        listen_cmd: Some(String::from(
+            r#"while true; do printf '{"alt":"first","text":"one"}
+'; sleep 0.1; done"#,
+        )),
+        icons: None,
+        alert: None,
+    };
+
+    custom
+        .register(&context, Some(&first))
+        .expect("first register");
+
+    timeout(Duration::from_secs(2), async {
+        loop {
+            if let Some(event) = receiver.try_recv().expect("receive") {
+                if let BusEvent::Module(ModuleEvent::Custom { name, message }) = event {
+                    if name.as_ref() == "first" {
+                        if matches!(message, Message::Event(ServiceEvent::Update(_))) {
+                            break;
+                        }
+                    }
+                }
+            }
+            sleep(Duration::from_millis(50)).await;
+        }
+    })
+    .await
+    .expect("first update");
+
+    while let Some(Some(_)) = receiver.try_recv().ok() {}
+
+    let second = CustomModuleDef {
+        name: String::from("second"),
+        command: String::from("true"),
+        icon: None,
+        listen_cmd: Some(String::from(
+            r#"while true; do printf '{"alt":"second","text":"two"}
+'; sleep 0.1; done"#,
+        )),
+        icons: None,
+        alert: None,
+    };
+
+    custom
+        .register(&context, Some(&second))
+        .expect("second register");
+
+    let observed = timeout(Duration::from_secs(2), async {
+        let mut alts = Vec::new();
+        loop {
+            if let Some(event) = receiver.try_recv().expect("receive") {
+                if let BusEvent::Module(ModuleEvent::Custom { name, message }) = event {
+                    if let Message::Event(ServiceEvent::Update(data)) = message {
+                        alts.push((name, data.alt));
+                        if alts.len() >= 3 {
+                            break alts;
+                        }
+                    }
+                }
+            }
+            sleep(Duration::from_millis(50)).await;
+        }
+    })
+    .await
+    .expect("collected updates");
+
+    assert!(
+        observed
+            .iter()
+            .all(|(name, alt)| { name.as_ref() == "second" && alt == "second" })
+    );
+}


### PR DESCRIPTION
## Summary
- cache the custom module event sender and spawn listener tasks through the shared runtime, aborting any previous handles during registration
- convert custom listener forwarding to use ModuleEvent::Custom via ModuleEventSender, emitting ModuleError on bus failures and removing the iced subscription bridge
- extend test coverage for custom listener error propagation and registration cancellation, and bump the workspace version to 0.6.1 with matching changelog entry

## Testing
- cargo +nightly fmt --
- cargo +1.90.0 clippy -- -D warnings *(fails: missing system library `xkbcommon` required by smithay-client-toolkit)*
- cargo +1.90.0 build --all-targets *(fails: missing system library `xkbcommon` required by smithay-client-toolkit)*
- cargo +1.90.0 test --all *(fails: missing system library `xkbcommon` required by smithay-client-toolkit)*
- cargo +1.90.0 doc --no-deps *(fails: missing system library `xkbcommon` required by smithay-client-toolkit)*
- cargo +1.90.0 audit *(warns about upstream unmaintained dependencies: derivative, instant, paste via iced stack)*
- cargo +1.90.0 deny check *(fails to fetch advisory database from GitHub)*

------
https://chatgpt.com/codex/tasks/task_e_68d878b3f6f0832bb1f2c315d636fb1e