### PR TITLE
Refactor Hyprland client adapter into modular components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.3] - 2025-09-29
+
+### Changed
+
+- Reorganized the Hyprland client adapter into focused `config`, `sync_ops`,
+  and `listeners` modules, keeping the facade slim while re-exporting the
+  public surface.
+- Centralized retry and backoff utilities for synchronous requests and event
+  listeners to reuse.
+
+### Added
+
+- Unit tests covering the new retry delay helpers and listener backoff guard
+  paths.
+
 ## [0.6.2] - 2025-09-28
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2265,7 +2265,7 @@ dependencies = [
 
 [[package]]
 name = "hydebar-app"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "clap",
  "flexi_logger",
@@ -2279,7 +2279,7 @@ dependencies = [
 
 [[package]]
 name = "hydebar-core"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2314,7 +2314,7 @@ dependencies = [
 
 [[package]]
 name = "hydebar-gui"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "flexi_logger",
  "hydebar-core",
@@ -2326,7 +2326,7 @@ dependencies = [
 
 [[package]]
 name = "hydebar-proto"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "hex_color",
  "iced",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.6.2"
+version = "0.6.3"
 edition = "2024"
 rust-version = "1.90"
 

--- a/crates/hydebar-core/src/adapters/hyprland_client.rs
+++ b/crates/hydebar-core/src/adapters/hyprland_client.rs
@@ -1,4 +1,9 @@
-use std::{sync::Arc, thread, time::Duration};
+mod config;
+mod listeners;
+mod sync_ops;
+mod util;
+
+use std::sync::Arc;
 
 use hydebar_proto::ports::hyprland::{
     HyprlandError, HyprlandEventStream, HyprlandKeyboardEvent, HyprlandKeyboardState,
@@ -10,51 +15,21 @@ use hyprland::{
     ctl::switch_xkb_layout::SwitchXKBLayoutCmdTypes,
     data::{Client, Devices, Monitors, Workspace, Workspaces},
     dispatch::{Dispatch, DispatchType, MonitorIdentifier, WorkspaceIdentifierWithSpecial},
-    event_listener::AsyncEventListener,
     keyword::Keyword,
 };
-use log::warn;
-use tokio::{
-    runtime::Handle,
-    sync::mpsc,
-    time::{sleep, timeout},
-};
-use tokio_stream::wrappers::ReceiverStream;
 
-const CHANNEL_CAPACITY: usize = 64;
-const WINDOW_EVENTS_OP: &str = "window_events";
-const WORKSPACE_EVENTS_OP: &str = "workspace_events";
-const KEYBOARD_EVENTS_OP: &str = "keyboard_events";
+pub use self::config::HyprlandClientConfig;
+use self::{
+    listeners::{spawn_keyboard_listener, spawn_window_listener, spawn_workspace_listener},
+    sync_ops::execute_with_retry,
+};
+
 const WORKSPACE_SNAPSHOT_OP: &str = "workspace_snapshot";
 const ACTIVE_WINDOW_OP: &str = "active_window";
 const CHANGE_WORKSPACE_OP: &str = "change_workspace";
 const TOGGLE_SPECIAL_OP: &str = "toggle_special_workspace";
 const KEYBOARD_STATE_OP: &str = "keyboard_state";
 const SWITCH_LAYOUT_OP: &str = "switch_keyboard_layout";
-
-/// Configuration options for [`HyprlandClient`].
-#[derive(Clone, Debug)]
-pub struct HyprlandClientConfig {
-    /// Maximum duration to wait for a synchronous Hyprland request to complete.
-    pub request_timeout: Duration,
-    /// Maximum time to wait for the Hyprland event listener to yield before treating it as hung.
-    pub listener_timeout: Duration,
-    /// Total number of retry attempts for synchronous Hyprland requests.
-    pub retry_attempts: u8,
-    /// Base delay between retry attempts for synchronous Hyprland requests.
-    pub retry_backoff: Duration,
-}
-
-impl Default for HyprlandClientConfig {
-    fn default() -> Self {
-        Self {
-            request_timeout: Duration::from_secs(2),
-            listener_timeout: Duration::from_secs(60),
-            retry_attempts: 3,
-            retry_backoff: Duration::from_millis(250),
-        }
-    }
-}
 
 /// [`HyprlandPort`] implementation backed by the `hyprland-rs` crate.
 #[derive(Clone, Debug)]
@@ -84,7 +59,7 @@ impl HyprlandClient {
         }
     }
 
-    fn backend_error<E>(operation: &'static str, err: E) -> HyprlandError
+    pub(crate) fn backend_error<E>(operation: &'static str, err: E) -> HyprlandError
     where
         E: std::error::Error + Send + Sync + 'static,
     {
@@ -94,585 +69,30 @@ impl HyprlandClient {
         }
     }
 
-    fn execute_once<R, F>(
-        operation: &'static str,
-        timeout_dur: Duration,
-        func: Arc<F>,
-    ) -> Result<R, HyprlandError>
-    where
-        R: Send + 'static,
-        F: Fn() -> Result<R, HyprlandError> + Send + Sync + 'static,
-    {
-        let (tx, rx) = std::sync::mpsc::channel();
-        thread::spawn(move || {
-            let result = func();
-            if tx.send(result).is_err() {
-                warn!(
-                    target: "hydebar::hyprland",
-                    "result receiver dropped before completion (operation={operation})"
-                );
-            }
-        });
-
-        match rx.recv_timeout(timeout_dur) {
-            Ok(result) => result,
-            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => Err(HyprlandError::Timeout {
-                operation,
-                timeout: timeout_dur,
-            }),
-            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => Err(HyprlandError::message(
-                operation,
-                "worker thread terminated before sending result",
-            )),
-        }
-    }
-
     fn execute_with_retry<R, F>(&self, operation: &'static str, func: F) -> Result<R, HyprlandError>
     where
         R: Send + 'static,
         F: Fn() -> Result<R, HyprlandError> + Send + Sync + 'static,
     {
-        let func = Arc::new(func);
-        let mut last_error = None;
-        for attempt in 1..=self.config.retry_attempts {
-            let func_clone = Arc::clone(&func);
-            match Self::execute_once(operation, self.config.request_timeout, func_clone) {
-                Ok(result) => return Ok(result),
-                Err(err) => {
-                    warn!(
-                        target: "hydebar::hyprland",
-                        "Hyprland operation failed (operation={operation}, attempt={attempt}, error={err})"
-                    );
-                    last_error = Some(err);
-                    if attempt < self.config.retry_attempts {
-                        let delay = self.config.retry_backoff.saturating_mul(u32::from(attempt));
-                        thread::sleep(delay);
-                    }
-                }
-            }
-        }
-        Err(last_error.unwrap_or_else(|| {
-            HyprlandError::message(operation, "Hyprland operation failed without error detail")
-        }))
+        execute_with_retry(&self.config, operation, func)
     }
 
     fn spawn_window_listener(
         &self,
     ) -> Result<HyprlandEventStream<HyprlandWindowEvent>, HyprlandError> {
-        let handle = Handle::try_current()
-            .map_err(|_| HyprlandError::runtime_unavailable(WINDOW_EVENTS_OP))?;
-        let (tx, rx) = mpsc::channel(CHANNEL_CAPACITY);
-        let listener_timeout = self.config.listener_timeout;
-        let retry_backoff = self.config.retry_backoff;
-
-        handle.spawn(async move {
-            let mut tx = tx;
-            loop {
-                let mut listener = AsyncEventListener::new();
-
-                listener.add_active_window_changed_handler({
-                    let tx = tx.clone();
-                    move |_| {
-                        let tx = tx.clone();
-                        Box::pin(async move {
-                            if let Err(err) =
-                                tx.send(Ok(HyprlandWindowEvent::ActiveWindowChanged)).await
-                            {
-                                warn!(
-                                    target: "hydebar::hyprland",
-                                    "window event receiver dropped (operation={}, error={err})",
-                                    WINDOW_EVENTS_OP
-                                );
-                            }
-                        })
-                    }
-                });
-
-                listener.add_window_closed_handler({
-                    let tx = tx.clone();
-                    move |_| {
-                        let tx = tx.clone();
-                        Box::pin(async move {
-                            if let Err(err) = tx.send(Ok(HyprlandWindowEvent::WindowClosed)).await {
-                                warn!(
-                                    target: "hydebar::hyprland",
-                                    "window event receiver dropped (operation={}, error={err})",
-                                    WINDOW_EVENTS_OP
-                                );
-                            }
-                        })
-                    }
-                });
-
-                listener.add_workspace_changed_handler({
-                    let tx = tx.clone();
-                    move |_| {
-                        let tx = tx.clone();
-                        Box::pin(async move {
-                            if let Err(err) = tx
-                                .send(Ok(HyprlandWindowEvent::WorkspaceFocusChanged))
-                                .await
-                            {
-                                warn!(
-                                    target: "hydebar::hyprland",
-                                    "window event receiver dropped (operation={}, error={err})",
-                                    WINDOW_EVENTS_OP
-                                );
-                            }
-                        })
-                    }
-                });
-
-                let result = timeout(listener_timeout, listener.start_listener_async()).await;
-                match result {
-                    Ok(Ok(())) => {
-                        warn!(
-                            target: "hydebar::hyprland",
-                            "window listener stopped unexpectedly (operation={})",
-                            WINDOW_EVENTS_OP
-                        );
-                    }
-                    Ok(Err(err)) => {
-                        let send_err = tx
-                            .send(Err(HyprlandClient::backend_error(WINDOW_EVENTS_OP, err)))
-                            .await;
-                        if let Err(send_err) = send_err {
-                            warn!(
-                                target: "hydebar::hyprland",
-                                "failed to publish window listener error (operation={}, error={send_err})",
-                                WINDOW_EVENTS_OP
-                            );
-                            break;
-                        }
-                    }
-                    Err(_) => {
-                        let send_err = tx
-                            .send(Err(HyprlandError::Timeout {
-                                operation: WINDOW_EVENTS_OP,
-                                timeout: listener_timeout,
-                            }))
-                            .await;
-                        if let Err(send_err) = send_err {
-                            warn!(
-                                target: "hydebar::hyprland",
-                                "failed to publish window listener timeout (operation={}, error={send_err})",
-                                WINDOW_EVENTS_OP
-                            );
-                            break;
-                        }
-                    }
-                }
-
-                if tx.is_closed() {
-                    break;
-                }
-
-                sleep(retry_backoff).await;
-            }
-        });
-
-        Ok(Box::pin(ReceiverStream::new(rx)))
+        spawn_window_listener(self.config.clone())
     }
 
     fn spawn_workspace_listener(
         &self,
     ) -> Result<HyprlandEventStream<HyprlandWorkspaceEvent>, HyprlandError> {
-        let handle = Handle::try_current()
-            .map_err(|_| HyprlandError::runtime_unavailable(WORKSPACE_EVENTS_OP))?;
-        let (tx, rx) = mpsc::channel(CHANNEL_CAPACITY);
-        let listener_timeout = self.config.listener_timeout;
-        let retry_backoff = self.config.retry_backoff;
-
-        handle.spawn(async move {
-            let mut tx = tx;
-            loop {
-                let mut listener = AsyncEventListener::new();
-
-                listener.add_workspace_added_handler({
-                    let tx = tx.clone();
-                    move |_| {
-                        let tx = tx.clone();
-                        Box::pin(async move {
-                            if let Err(err) = tx.send(Ok(HyprlandWorkspaceEvent::Added)).await {
-                                warn!(
-                                    target: "hydebar::hyprland",
-                                    "workspace event receiver dropped (operation={}, error={err})",
-                                    WORKSPACE_EVENTS_OP
-                                );
-                            }
-                        })
-                    }
-                });
-
-                listener.add_workspace_changed_handler({
-                    let tx = tx.clone();
-                    move |_| {
-                        let tx = tx.clone();
-                        Box::pin(async move {
-                            if let Err(err) = tx.send(Ok(HyprlandWorkspaceEvent::Changed)).await {
-                                warn!(
-                                    target: "hydebar::hyprland",
-                                    "workspace event receiver dropped (operation={}, error={err})",
-                                    WORKSPACE_EVENTS_OP
-                                );
-                            }
-                        })
-                    }
-                });
-
-                listener.add_workspace_deleted_handler({
-                    let tx = tx.clone();
-                    move |_| {
-                        let tx = tx.clone();
-                        Box::pin(async move {
-                            if let Err(err) = tx.send(Ok(HyprlandWorkspaceEvent::Removed)).await {
-                                warn!(
-                                    target: "hydebar::hyprland",
-                                    "workspace event receiver dropped (operation={}, error={err})",
-                                    WORKSPACE_EVENTS_OP
-                                );
-                            }
-                        })
-                    }
-                });
-
-                listener.add_workspace_moved_handler({
-                    let tx = tx.clone();
-                    move |_| {
-                        let tx = tx.clone();
-                        Box::pin(async move {
-                            if let Err(err) = tx.send(Ok(HyprlandWorkspaceEvent::Moved)).await {
-                                warn!(
-                                    target: "hydebar::hyprland",
-                                    "workspace event receiver dropped (operation={}, error={err})",
-                                    WORKSPACE_EVENTS_OP
-                                );
-                            }
-                        })
-                    }
-                });
-
-                listener.add_changed_special_handler({
-                    let tx = tx.clone();
-                    move |_| {
-                        let tx = tx.clone();
-                        Box::pin(async move {
-                            if let Err(err) =
-                                tx.send(Ok(HyprlandWorkspaceEvent::SpecialChanged)).await
-                            {
-                                warn!(
-                                    target: "hydebar::hyprland",
-                                    "workspace event receiver dropped (operation={}, error={err})",
-                                    WORKSPACE_EVENTS_OP
-                                );
-                            }
-                        })
-                    }
-                });
-
-                listener.add_special_removed_handler({
-                    let tx = tx.clone();
-                    move |_| {
-                        let tx = tx.clone();
-                        Box::pin(async move {
-                            if let Err(err) =
-                                tx.send(Ok(HyprlandWorkspaceEvent::SpecialRemoved)).await
-                            {
-                                warn!(
-                                    target: "hydebar::hyprland",
-                                    "workspace event receiver dropped (operation={}, error={err})",
-                                    WORKSPACE_EVENTS_OP
-                                );
-                            }
-                        })
-                    }
-                });
-
-                listener.add_window_closed_handler({
-                    let tx = tx.clone();
-                    move |_| {
-                        let tx = tx.clone();
-                        Box::pin(async move {
-                            if let Err(err) =
-                                tx.send(Ok(HyprlandWorkspaceEvent::WindowClosed)).await
-                            {
-                                warn!(
-                                    target: "hydebar::hyprland",
-                                    "workspace event receiver dropped (operation={}, error={err})",
-                                    WORKSPACE_EVENTS_OP
-                                );
-                            }
-                        })
-                    }
-                });
-
-                listener.add_window_opened_handler({
-                    let tx = tx.clone();
-                    move |_| {
-                        let tx = tx.clone();
-                        Box::pin(async move {
-                            if let Err(err) =
-                                tx.send(Ok(HyprlandWorkspaceEvent::WindowOpened)).await
-                            {
-                                warn!(
-                                    target: "hydebar::hyprland",
-                                    "workspace event receiver dropped (operation={}, error={err})",
-                                    WORKSPACE_EVENTS_OP
-                                );
-                            }
-                        })
-                    }
-                });
-
-                listener.add_window_moved_handler({
-                    let tx = tx.clone();
-                    move |_| {
-                        let tx = tx.clone();
-                        Box::pin(async move {
-                            if let Err(err) = tx.send(Ok(HyprlandWorkspaceEvent::WindowMoved)).await
-                            {
-                                warn!(
-                                    target: "hydebar::hyprland",
-                                    "workspace event receiver dropped (operation={}, error={err})",
-                                    WORKSPACE_EVENTS_OP
-                                );
-                            }
-                        })
-                    }
-                });
-
-                listener.add_active_monitor_changed_handler({
-                    let tx = tx.clone();
-                    move |_| {
-                        let tx = tx.clone();
-                        Box::pin(async move {
-                            if let Err(err) = tx
-                                .send(Ok(HyprlandWorkspaceEvent::ActiveMonitorChanged))
-                                .await
-                            {
-                                warn!(
-                                    target: "hydebar::hyprland",
-                                    "workspace event receiver dropped (operation={}, error={err})",
-                                    WORKSPACE_EVENTS_OP
-                                );
-                            }
-                        })
-                    }
-                });
-
-                let result = timeout(listener_timeout, listener.start_listener_async()).await;
-                match result {
-                    Ok(Ok(())) => {
-                        warn!(
-                            target: "hydebar::hyprland",
-                            "workspace listener stopped unexpectedly (operation={})",
-                            WORKSPACE_EVENTS_OP
-                        );
-                    }
-                    Ok(Err(err)) => {
-                        let send_err = tx
-                            .send(Err(HyprlandClient::backend_error(WORKSPACE_EVENTS_OP, err)))
-                            .await;
-                        if let Err(send_err) = send_err {
-                            warn!(
-                                target: "hydebar::hyprland",
-                                "failed to publish workspace listener error (operation={}, error={send_err})",
-                                WORKSPACE_EVENTS_OP
-                            );
-                            break;
-                        }
-                    }
-                    Err(_) => {
-                        let send_err = tx
-                            .send(Err(HyprlandError::Timeout {
-                                operation: WORKSPACE_EVENTS_OP,
-                                timeout: listener_timeout,
-                            }))
-                            .await;
-                        if let Err(send_err) = send_err {
-                            warn!(
-                                target: "hydebar::hyprland",
-                                "failed to publish workspace listener timeout (operation={}, error={send_err})",
-                                WORKSPACE_EVENTS_OP
-                            );
-                            break;
-                        }
-                    }
-                }
-
-                if tx.is_closed() {
-                    break;
-                }
-
-                sleep(retry_backoff).await;
-            }
-        });
-
-        Ok(Box::pin(ReceiverStream::new(rx)))
+        spawn_workspace_listener(self.config.clone())
     }
 
     fn spawn_keyboard_listener(
         &self,
     ) -> Result<HyprlandEventStream<HyprlandKeyboardEvent>, HyprlandError> {
-        let handle = Handle::try_current()
-            .map_err(|_| HyprlandError::runtime_unavailable(KEYBOARD_EVENTS_OP))?;
-        let (tx, rx) = mpsc::channel(CHANNEL_CAPACITY);
-        let listener_timeout = self.config.listener_timeout;
-        let retry_backoff = self.config.retry_backoff;
-        let client = self.clone();
-
-        handle.spawn(async move {
-            let mut tx = tx;
-            loop {
-                let mut listener = AsyncEventListener::new();
-
-                listener.add_layout_changed_handler({
-                    let tx = tx.clone();
-                    let client = client.clone();
-                    move |_| {
-                        let tx = tx.clone();
-                        let client = client.clone();
-                        Box::pin(async move {
-                            match client.keyboard_state() {
-                                Ok(state) => {
-                                    if let Err(err) = tx
-                                        .send(Ok(HyprlandKeyboardEvent::LayoutChanged(
-                                            state.active_layout,
-                                        )))
-                                        .await
-                                    {
-                                        warn!(
-                                            target: "hydebar::hyprland",
-                                            "keyboard event receiver dropped (operation={}, error={err})",
-                                            KEYBOARD_EVENTS_OP
-                                        );
-                                    }
-                                }
-                                Err(err) => {
-                                    if let Err(send_err) = tx.send(Err(err)).await {
-                                        warn!(
-                                            target: "hydebar::hyprland",
-                                            "failed to publish keyboard state error (operation={}, error={send_err})",
-                                            KEYBOARD_EVENTS_OP
-                                        );
-                                    }
-                                }
-                            }
-                        })
-                    }
-                });
-
-                listener.add_config_reloaded_handler({
-                    let tx = tx.clone();
-                    let client = client.clone();
-                    move || {
-                        let tx = tx.clone();
-                        let client = client.clone();
-                        Box::pin(async move {
-                            match client.keyboard_state() {
-                                Ok(state) => {
-                                    if let Err(err) = tx
-                                        .send(Ok(
-                                            HyprlandKeyboardEvent::LayoutConfigurationChanged(
-                                                state.has_multiple_layouts,
-                                            ),
-                                        ))
-                                        .await
-                                    {
-                                        warn!(
-                                            target: "hydebar::hyprland",
-                                            "keyboard event receiver dropped (operation={}, error={err})",
-                                            KEYBOARD_EVENTS_OP
-                                        );
-                                    }
-                                }
-                                Err(err) => {
-                                    if let Err(send_err) = tx.send(Err(err)).await {
-                                        warn!(
-                                            target: "hydebar::hyprland",
-                                            "failed to publish keyboard config error (operation={}, error={send_err})",
-                                            KEYBOARD_EVENTS_OP
-                                        );
-                                    }
-                                }
-                            }
-                        })
-                    }
-                });
-
-                listener.add_sub_map_changed_handler({
-                    let tx = tx.clone();
-                    move |submap| {
-                        let tx = tx.clone();
-                        Box::pin(async move {
-                            let payload = if submap.trim().is_empty() {
-                                None
-                            } else {
-                                Some(submap)
-                            };
-                            if let Err(err) = tx
-                                .send(Ok(HyprlandKeyboardEvent::SubmapChanged(payload)))
-                                .await
-                            {
-                                warn!(
-                                    target: "hydebar::hyprland",
-                                    "keyboard event receiver dropped (operation={}, error={err})",
-                                    KEYBOARD_EVENTS_OP
-                                );
-                            }
-                        })
-                    }
-                });
-
-                let result = timeout(listener_timeout, listener.start_listener_async()).await;
-                match result {
-                    Ok(Ok(())) => {
-                        warn!(
-                            target: "hydebar::hyprland",
-                            "keyboard listener stopped unexpectedly (operation={})",
-                            KEYBOARD_EVENTS_OP
-                        );
-                    }
-                    Ok(Err(err)) => {
-                        let send_err = tx
-                            .send(Err(HyprlandClient::backend_error(KEYBOARD_EVENTS_OP, err)))
-                            .await;
-                        if let Err(send_err) = send_err {
-                            warn!(
-                                target: "hydebar::hyprland",
-                                "failed to publish keyboard listener error (operation={}, error={send_err})",
-                                KEYBOARD_EVENTS_OP
-                            );
-                            break;
-                        }
-                    }
-                    Err(_) => {
-                        let send_err = tx
-                            .send(Err(HyprlandError::Timeout {
-                                operation: KEYBOARD_EVENTS_OP,
-                                timeout: listener_timeout,
-                            }))
-                            .await;
-                        if let Err(send_err) = send_err {
-                            warn!(
-                                target: "hydebar::hyprland",
-                                "failed to publish keyboard listener timeout (operation={}, error={send_err})",
-                                KEYBOARD_EVENTS_OP
-                            );
-                            break;
-                        }
-                    }
-                }
-
-                if tx.is_closed() {
-                    break;
-                }
-
-                sleep(retry_backoff).await;
-            }
-        });
-
-        Ok(Box::pin(ReceiverStream::new(rx)))
+        spawn_keyboard_listener(self.clone(), self.config.clone())
     }
 }
 

--- a/crates/hydebar-core/src/adapters/hyprland_client/config.rs
+++ b/crates/hydebar-core/src/adapters/hyprland_client/config.rs
@@ -1,0 +1,50 @@
+use std::time::Duration;
+
+/// Configuration options for [`HyprlandClient`](super::HyprlandClient).
+///
+/// # Examples
+///
+/// ```no_run
+/// use hydebar_core::adapters::hyprland_client::{HyprlandClient, HyprlandClientConfig};
+///
+/// let client = HyprlandClient::with_config(HyprlandClientConfig::default());
+/// assert!(client.active_window().is_ok());
+/// ```
+#[derive(Clone, Debug)]
+pub struct HyprlandClientConfig {
+    /// Maximum duration to wait for a synchronous Hyprland request to complete.
+    pub request_timeout: Duration,
+    /// Maximum time to wait for the Hyprland event listener to yield before treating it as hung.
+    pub listener_timeout: Duration,
+    /// Total number of retry attempts for synchronous Hyprland requests.
+    pub retry_attempts: u8,
+    /// Base delay between retry attempts for synchronous Hyprland requests.
+    pub retry_backoff: Duration,
+}
+
+impl Default for HyprlandClientConfig {
+    fn default() -> Self {
+        Self {
+            request_timeout: Duration::from_secs(2),
+            listener_timeout: Duration::from_secs(60),
+            retry_attempts: 3,
+            retry_backoff: Duration::from_millis(250),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::HyprlandClientConfig;
+    use std::time::Duration;
+
+    #[test]
+    fn default_values_are_sensible() {
+        let config = HyprlandClientConfig::default();
+
+        assert_eq!(config.request_timeout, Duration::from_secs(2));
+        assert_eq!(config.listener_timeout, Duration::from_secs(60));
+        assert_eq!(config.retry_attempts, 3);
+        assert_eq!(config.retry_backoff, Duration::from_millis(250));
+    }
+}

--- a/crates/hydebar-core/src/adapters/hyprland_client/listeners.rs
+++ b/crates/hydebar-core/src/adapters/hyprland_client/listeners.rs
@@ -1,0 +1,534 @@
+use std::sync::Arc;
+
+use hydebar_proto::ports::hyprland::{
+    HyprlandError, HyprlandEventStream, HyprlandKeyboardEvent, HyprlandPort, HyprlandWindowEvent,
+    HyprlandWorkspaceEvent,
+};
+use hyprland::event_listener::AsyncEventListener;
+use log::warn;
+use tokio::{runtime::Handle, sync::mpsc, time::timeout};
+use tokio_stream::wrappers::ReceiverStream;
+
+use super::{HyprlandClient, config::HyprlandClientConfig, util::sleep_with_backoff};
+
+const CHANNEL_CAPACITY: usize = 64;
+const WINDOW_EVENTS_OP: &str = "window_events";
+const WORKSPACE_EVENTS_OP: &str = "workspace_events";
+const KEYBOARD_EVENTS_OP: &str = "keyboard_events";
+
+pub(crate) fn spawn_window_listener(
+    config: Arc<HyprlandClientConfig>,
+) -> Result<HyprlandEventStream<HyprlandWindowEvent>, HyprlandError> {
+    let handle =
+        Handle::try_current().map_err(|_| HyprlandError::runtime_unavailable(WINDOW_EVENTS_OP))?;
+    let (tx, rx) = mpsc::channel(CHANNEL_CAPACITY);
+    let listener_timeout = config.listener_timeout;
+    let retry_backoff = config.retry_backoff;
+
+    handle.spawn(async move {
+        let mut tx = tx;
+        loop {
+            let mut listener = AsyncEventListener::new();
+
+            listener.add_active_window_changed_handler({
+                let tx = tx.clone();
+                move |_| {
+                    let tx = tx.clone();
+                    Box::pin(async move {
+                        if let Err(err) = tx.send(Ok(HyprlandWindowEvent::ActiveWindowChanged)).await
+                        {
+                            warn!(
+                                target: "hydebar::hyprland",
+                                "window event receiver dropped (operation={}, error={err})",
+                                WINDOW_EVENTS_OP
+                            );
+                        }
+                    })
+                }
+            });
+
+            listener.add_window_closed_handler({
+                let tx = tx.clone();
+                move |_| {
+                    let tx = tx.clone();
+                    Box::pin(async move {
+                        if let Err(err) = tx.send(Ok(HyprlandWindowEvent::WindowClosed)).await {
+                            warn!(
+                                target: "hydebar::hyprland",
+                                "window event receiver dropped (operation={}, error={err})",
+                                WINDOW_EVENTS_OP
+                            );
+                        }
+                    })
+                }
+            });
+
+            listener.add_workspace_changed_handler({
+                let tx = tx.clone();
+                move |_| {
+                    let tx = tx.clone();
+                    Box::pin(async move {
+                        if let Err(err) = tx
+                            .send(Ok(HyprlandWindowEvent::WorkspaceFocusChanged))
+                            .await
+                        {
+                            warn!(
+                                target: "hydebar::hyprland",
+                                "window event receiver dropped (operation={}, error={err})",
+                                WINDOW_EVENTS_OP
+                            );
+                        }
+                    })
+                }
+            });
+
+            let result = timeout(listener_timeout, listener.start_listener_async()).await;
+            match result {
+                Ok(Ok(())) => {
+                    warn!(
+                        target: "hydebar::hyprland",
+                        "window listener stopped unexpectedly (operation={})",
+                        WINDOW_EVENTS_OP
+                    );
+                }
+                Ok(Err(err)) => {
+                    let send_err = tx
+                        .send(Err(HyprlandClient::backend_error(WINDOW_EVENTS_OP, err)))
+                        .await;
+                    if let Err(send_err) = send_err {
+                        warn!(
+                            target: "hydebar::hyprland",
+                            "failed to publish window listener error (operation={}, error={send_err})",
+                            WINDOW_EVENTS_OP
+                        );
+                        break;
+                    }
+                }
+                Err(_) => {
+                    let send_err = tx
+                        .send(Err(HyprlandError::Timeout {
+                            operation: WINDOW_EVENTS_OP,
+                            timeout: listener_timeout,
+                        }))
+                        .await;
+                    if let Err(send_err) = send_err {
+                        warn!(
+                            target: "hydebar::hyprland",
+                            "failed to publish window listener timeout (operation={}, error={send_err})",
+                            WINDOW_EVENTS_OP
+                        );
+                        break;
+                    }
+                }
+            }
+
+            if tx.is_closed() {
+                break;
+            }
+
+            sleep_with_backoff(retry_backoff).await;
+        }
+    });
+
+    Ok(Box::pin(ReceiverStream::new(rx)))
+}
+
+pub(crate) fn spawn_workspace_listener(
+    config: Arc<HyprlandClientConfig>,
+) -> Result<HyprlandEventStream<HyprlandWorkspaceEvent>, HyprlandError> {
+    let handle = Handle::try_current()
+        .map_err(|_| HyprlandError::runtime_unavailable(WORKSPACE_EVENTS_OP))?;
+    let (tx, rx) = mpsc::channel(CHANNEL_CAPACITY);
+    let listener_timeout = config.listener_timeout;
+    let retry_backoff = config.retry_backoff;
+
+    handle.spawn(async move {
+        let mut tx = tx;
+        loop {
+            let mut listener = AsyncEventListener::new();
+
+            listener.add_workspace_added_handler({
+                let tx = tx.clone();
+                move |_| {
+                    let tx = tx.clone();
+                    Box::pin(async move {
+                        if let Err(err) = tx.send(Ok(HyprlandWorkspaceEvent::Added)).await {
+                            warn!(
+                                target: "hydebar::hyprland",
+                                "workspace event receiver dropped (operation={}, error={err})",
+                                WORKSPACE_EVENTS_OP
+                            );
+                        }
+                    })
+                }
+            });
+
+            listener.add_workspace_changed_handler({
+                let tx = tx.clone();
+                move |_| {
+                    let tx = tx.clone();
+                    Box::pin(async move {
+                        if let Err(err) = tx.send(Ok(HyprlandWorkspaceEvent::Changed)).await {
+                            warn!(
+                                target: "hydebar::hyprland",
+                                "workspace event receiver dropped (operation={}, error={err})",
+                                WORKSPACE_EVENTS_OP
+                            );
+                        }
+                    })
+                }
+            });
+
+            listener.add_workspace_deleted_handler({
+                let tx = tx.clone();
+                move |_| {
+                    let tx = tx.clone();
+                    Box::pin(async move {
+                        if let Err(err) = tx.send(Ok(HyprlandWorkspaceEvent::Removed)).await {
+                            warn!(
+                                target: "hydebar::hyprland",
+                                "workspace event receiver dropped (operation={}, error={err})",
+                                WORKSPACE_EVENTS_OP
+                            );
+                        }
+                    })
+                }
+            });
+
+            listener.add_workspace_moved_handler({
+                let tx = tx.clone();
+                move |_| {
+                    let tx = tx.clone();
+                    Box::pin(async move {
+                        if let Err(err) = tx.send(Ok(HyprlandWorkspaceEvent::Moved)).await {
+                            warn!(
+                                target: "hydebar::hyprland",
+                                "workspace event receiver dropped (operation={}, error={err})",
+                                WORKSPACE_EVENTS_OP
+                            );
+                        }
+                    })
+                }
+            });
+
+            listener.add_changed_special_handler({
+                let tx = tx.clone();
+                move |_| {
+                    let tx = tx.clone();
+                    Box::pin(async move {
+                        if let Err(err) = tx
+                            .send(Ok(HyprlandWorkspaceEvent::SpecialChanged))
+                            .await
+                        {
+                            warn!(
+                                target: "hydebar::hyprland",
+                                "workspace event receiver dropped (operation={}, error={err})",
+                                WORKSPACE_EVENTS_OP
+                            );
+                        }
+                    })
+                }
+            });
+
+            listener.add_special_removed_handler({
+                let tx = tx.clone();
+                move |_| {
+                    let tx = tx.clone();
+                    Box::pin(async move {
+                        if let Err(err) = tx
+                            .send(Ok(HyprlandWorkspaceEvent::SpecialRemoved))
+                            .await
+                        {
+                            warn!(
+                                target: "hydebar::hyprland",
+                                "workspace event receiver dropped (operation={}, error={err})",
+                                WORKSPACE_EVENTS_OP
+                            );
+                        }
+                    })
+                }
+            });
+
+            listener.add_window_closed_handler({
+                let tx = tx.clone();
+                move |_| {
+                    let tx = tx.clone();
+                    Box::pin(async move {
+                        if let Err(err) = tx
+                            .send(Ok(HyprlandWorkspaceEvent::WindowClosed))
+                            .await
+                        {
+                            warn!(
+                                target: "hydebar::hyprland",
+                                "workspace event receiver dropped (operation={}, error={err})",
+                                WORKSPACE_EVENTS_OP
+                            );
+                        }
+                    })
+                }
+            });
+
+            listener.add_window_opened_handler({
+                let tx = tx.clone();
+                move |_| {
+                    let tx = tx.clone();
+                    Box::pin(async move {
+                        if let Err(err) = tx
+                            .send(Ok(HyprlandWorkspaceEvent::WindowOpened))
+                            .await
+                        {
+                            warn!(
+                                target: "hydebar::hyprland",
+                                "workspace event receiver dropped (operation={}, error={err})",
+                                WORKSPACE_EVENTS_OP
+                            );
+                        }
+                    })
+                }
+            });
+
+            listener.add_window_moved_handler({
+                let tx = tx.clone();
+                move |_| {
+                    let tx = tx.clone();
+                    Box::pin(async move {
+                        if let Err(err) = tx.send(Ok(HyprlandWorkspaceEvent::WindowMoved)).await {
+                            warn!(
+                                target: "hydebar::hyprland",
+                                "workspace event receiver dropped (operation={}, error={err})",
+                                WORKSPACE_EVENTS_OP
+                            );
+                        }
+                    })
+                }
+            });
+
+            listener.add_active_monitor_changed_handler({
+                let tx = tx.clone();
+                move |_| {
+                    let tx = tx.clone();
+                    Box::pin(async move {
+                        if let Err(err) = tx
+                            .send(Ok(HyprlandWorkspaceEvent::ActiveMonitorChanged))
+                            .await
+                        {
+                            warn!(
+                                target: "hydebar::hyprland",
+                                "workspace event receiver dropped (operation={}, error={err})",
+                                WORKSPACE_EVENTS_OP
+                            );
+                        }
+                    })
+                }
+            });
+
+            let result = timeout(listener_timeout, listener.start_listener_async()).await;
+            match result {
+                Ok(Ok(())) => {
+                    warn!(
+                        target: "hydebar::hyprland",
+                        "workspace listener stopped unexpectedly (operation={})",
+                        WORKSPACE_EVENTS_OP
+                    );
+                }
+                Ok(Err(err)) => {
+                    let send_err = tx
+                        .send(Err(HyprlandClient::backend_error(WORKSPACE_EVENTS_OP, err)))
+                        .await;
+                    if let Err(send_err) = send_err {
+                        warn!(
+                            target: "hydebar::hyprland",
+                            "failed to publish workspace listener error (operation={}, error={send_err})",
+                            WORKSPACE_EVENTS_OP
+                        );
+                        break;
+                    }
+                }
+                Err(_) => {
+                    let send_err = tx
+                        .send(Err(HyprlandError::Timeout {
+                            operation: WORKSPACE_EVENTS_OP,
+                            timeout: listener_timeout,
+                        }))
+                        .await;
+                    if let Err(send_err) = send_err {
+                        warn!(
+                            target: "hydebar::hyprland",
+                            "failed to publish workspace listener timeout (operation={}, error={send_err})",
+                            WORKSPACE_EVENTS_OP
+                        );
+                        break;
+                    }
+                }
+            }
+
+            if tx.is_closed() {
+                break;
+            }
+
+            sleep_with_backoff(retry_backoff).await;
+        }
+    });
+
+    Ok(Box::pin(ReceiverStream::new(rx)))
+}
+
+pub(crate) fn spawn_keyboard_listener(
+    client: HyprlandClient,
+    config: Arc<HyprlandClientConfig>,
+) -> Result<HyprlandEventStream<HyprlandKeyboardEvent>, HyprlandError> {
+    let handle = Handle::try_current()
+        .map_err(|_| HyprlandError::runtime_unavailable(KEYBOARD_EVENTS_OP))?;
+    let (tx, rx) = mpsc::channel(CHANNEL_CAPACITY);
+    let listener_timeout = config.listener_timeout;
+    let retry_backoff = config.retry_backoff;
+
+    handle.spawn(async move {
+        let mut tx = tx;
+        loop {
+            let mut listener = AsyncEventListener::new();
+
+            listener.add_layout_changed_handler({
+                let tx = tx.clone();
+                let client = client.clone();
+                move |_| {
+                    let tx = tx.clone();
+                    let client = client.clone();
+                    Box::pin(async move {
+                        match client.keyboard_state() {
+                            Ok(state) => {
+                                if let Err(err) = tx
+                                    .send(Ok(HyprlandKeyboardEvent::LayoutChanged(state.active_layout)))
+                                    .await
+                                {
+                                    warn!(
+                                        target: "hydebar::hyprland",
+                                        "keyboard event receiver dropped (operation={}, error={err})",
+                                        KEYBOARD_EVENTS_OP
+                                    );
+                                }
+                            }
+                            Err(err) => {
+                                if let Err(send_err) = tx.send(Err(err)).await {
+                                    warn!(
+                                        target: "hydebar::hyprland",
+                                        "failed to publish keyboard state error (operation={}, error={send_err})",
+                                        KEYBOARD_EVENTS_OP
+                                    );
+                                }
+                            }
+                        }
+                    })
+                }
+            });
+
+            listener.add_config_reloaded_handler({
+                let tx = tx.clone();
+                let client = client.clone();
+                move || {
+                    let tx = tx.clone();
+                    let client = client.clone();
+                    Box::pin(async move {
+                        match client.keyboard_state() {
+                            Ok(state) => {
+                                if let Err(err) = tx
+                                    .send(Ok(HyprlandKeyboardEvent::LayoutConfigurationChanged(
+                                        state.has_multiple_layouts,
+                                    )))
+                                    .await
+                                {
+                                    warn!(
+                                        target: "hydebar::hyprland",
+                                        "keyboard event receiver dropped (operation={}, error={err})",
+                                        KEYBOARD_EVENTS_OP
+                                    );
+                                }
+                            }
+                            Err(err) => {
+                                if let Err(send_err) = tx.send(Err(err)).await {
+                                    warn!(
+                                        target: "hydebar::hyprland",
+                                        "failed to publish keyboard config error (operation={}, error={send_err})",
+                                        KEYBOARD_EVENTS_OP
+                                    );
+                                }
+                            }
+                        }
+                    })
+                }
+            });
+
+            listener.add_sub_map_changed_handler({
+                let tx = tx.clone();
+                move |submap| {
+                    let tx = tx.clone();
+                    Box::pin(async move {
+                        let payload = if submap.trim().is_empty() {
+                            None
+                        } else {
+                            Some(submap)
+                        };
+                        if let Err(err) = tx
+                            .send(Ok(HyprlandKeyboardEvent::SubmapChanged(payload)))
+                            .await
+                        {
+                            warn!(
+                                target: "hydebar::hyprland",
+                                "keyboard event receiver dropped (operation={}, error={err})",
+                                KEYBOARD_EVENTS_OP
+                            );
+                        }
+                    })
+                }
+            });
+
+            let result = timeout(listener_timeout, listener.start_listener_async()).await;
+            match result {
+                Ok(Ok(())) => {
+                    warn!(
+                        target: "hydebar::hyprland",
+                        "keyboard listener stopped unexpectedly (operation={})",
+                        KEYBOARD_EVENTS_OP
+                    );
+                }
+                Ok(Err(err)) => {
+                    let send_err = tx
+                        .send(Err(HyprlandClient::backend_error(KEYBOARD_EVENTS_OP, err)))
+                        .await;
+                    if let Err(send_err) = send_err {
+                        warn!(
+                            target: "hydebar::hyprland",
+                            "failed to publish keyboard listener error (operation={}, error={send_err})",
+                            KEYBOARD_EVENTS_OP
+                        );
+                        break;
+                    }
+                }
+                Err(_) => {
+                    let send_err = tx
+                        .send(Err(HyprlandError::Timeout {
+                            operation: KEYBOARD_EVENTS_OP,
+                            timeout: listener_timeout,
+                        }))
+                        .await;
+                    if let Err(send_err) = send_err {
+                        warn!(
+                            target: "hydebar::hyprland",
+                            "failed to publish keyboard listener timeout (operation={}, error={send_err})",
+                            KEYBOARD_EVENTS_OP
+                        );
+                        break;
+                    }
+                }
+            }
+
+            if tx.is_closed() {
+                break;
+            }
+
+            sleep_with_backoff(retry_backoff).await;
+        }
+    });
+
+    Ok(Box::pin(ReceiverStream::new(rx)))
+}

--- a/crates/hydebar-core/src/adapters/hyprland_client/sync_ops.rs
+++ b/crates/hydebar-core/src/adapters/hyprland_client/sync_ops.rs
@@ -1,0 +1,131 @@
+use std::{sync::Arc, thread, time::Duration};
+
+use hydebar_proto::ports::hyprland::HyprlandError;
+use log::warn;
+
+use super::{config::HyprlandClientConfig, util::calculate_retry_delay};
+
+/// Execute a blocking Hyprland request in a worker thread and wait for it to
+/// complete within the provided timeout.
+pub(crate) fn execute_once<R, F>(
+    operation: &'static str,
+    timeout_dur: Duration,
+    func: Arc<F>,
+) -> Result<R, HyprlandError>
+where
+    R: Send + 'static,
+    F: Fn() -> Result<R, HyprlandError> + Send + Sync + 'static,
+{
+    let (tx, rx) = std::sync::mpsc::channel();
+    thread::spawn(move || {
+        let result = func();
+        if tx.send(result).is_err() {
+            warn!(
+                target: "hydebar::hyprland",
+                "result receiver dropped before completion (operation={operation})"
+            );
+        }
+    });
+
+    match rx.recv_timeout(timeout_dur) {
+        Ok(result) => result,
+        Err(std::sync::mpsc::RecvTimeoutError::Timeout) => Err(HyprlandError::Timeout {
+            operation,
+            timeout: timeout_dur,
+        }),
+        Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => Err(HyprlandError::message(
+            operation,
+            "worker thread terminated before sending result",
+        )),
+    }
+}
+
+/// Execute a blocking Hyprland request with retry and backoff semantics derived
+/// from [`HyprlandClientConfig`].
+pub(crate) fn execute_with_retry<R, F>(
+    config: &HyprlandClientConfig,
+    operation: &'static str,
+    func: F,
+) -> Result<R, HyprlandError>
+where
+    R: Send + 'static,
+    F: Fn() -> Result<R, HyprlandError> + Send + Sync + 'static,
+{
+    let func = Arc::new(func);
+    let mut last_error = None;
+
+    for attempt in 1..=config.retry_attempts {
+        let func_clone = Arc::clone(&func);
+        match execute_once(operation, config.request_timeout, func_clone) {
+            Ok(result) => return Ok(result),
+            Err(err) => {
+                warn!(
+                    target: "hydebar::hyprland",
+                    "Hyprland operation failed (operation={operation}, attempt={attempt}, error={err})"
+                );
+                last_error = Some(err);
+                if attempt < config.retry_attempts {
+                    let delay = calculate_retry_delay(config.retry_backoff, attempt);
+                    if !delay.is_zero() {
+                        thread::sleep(delay);
+                    }
+                }
+            }
+        }
+    }
+
+    Err(last_error.unwrap_or_else(|| {
+        HyprlandError::message(operation, "Hyprland operation failed without error detail")
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    fn base_config() -> HyprlandClientConfig {
+        HyprlandClientConfig {
+            request_timeout: Duration::from_millis(50),
+            listener_timeout: Duration::from_secs(1),
+            retry_attempts: 3,
+            retry_backoff: Duration::ZERO,
+        }
+    }
+
+    #[test]
+    fn execute_once_propagates_success() {
+        let result = execute_once("test", Duration::from_secs(1), Arc::new(|| Ok(42)));
+        assert_eq!(result.unwrap(), 42);
+    }
+
+    #[test]
+    fn execute_with_retry_eventually_succeeds() {
+        let counter = AtomicUsize::new(0);
+        let result = execute_with_retry(&base_config(), "retry", || {
+            let value = counter.fetch_add(1, Ordering::SeqCst);
+            if value < 2 {
+                Err(HyprlandError::message("retry", "try again"))
+            } else {
+                Ok(value)
+            }
+        });
+
+        assert_eq!(result.unwrap(), 2);
+    }
+
+    #[test]
+    fn execute_with_retry_returns_last_error() {
+        let error = execute_with_retry(&base_config(), "retry", || {
+            Err(HyprlandError::message("retry", "failed"))
+        })
+        .unwrap_err();
+
+        assert!(matches!(
+            error,
+            HyprlandError::Backend { .. }
+                | HyprlandError::Message { .. }
+                | HyprlandError::Timeout { .. }
+        ));
+    }
+}

--- a/crates/hydebar-core/src/adapters/hyprland_client/util.rs
+++ b/crates/hydebar-core/src/adapters/hyprland_client/util.rs
@@ -1,0 +1,71 @@
+use std::time::Duration;
+
+use tokio::time::sleep;
+
+/// Compute the delay to wait before retrying an operation using linear backoff.
+///
+/// The returned duration is `base_backoff * attempt` with saturating multiplication.
+///
+/// # Examples
+///
+/// ```ignore
+/// use std::time::Duration;
+/// use hydebar_core::adapters::hyprland_client::util::calculate_retry_delay;
+///
+/// let delay = calculate_retry_delay(Duration::from_millis(100), 3);
+/// assert_eq!(delay, Duration::from_millis(300));
+/// ```
+pub(crate) fn calculate_retry_delay(base_backoff: Duration, attempt: u8) -> Duration {
+    if attempt == 0 {
+        return Duration::ZERO;
+    }
+
+    base_backoff.saturating_mul(u32::from(attempt))
+}
+
+/// Sleep for the provided backoff duration if it is non-zero.
+///
+/// This helper keeps listener retry loops concise and avoids duplicating the
+/// zero-duration guard at each call site.
+pub(crate) async fn sleep_with_backoff(backoff: Duration) {
+    if backoff.is_zero() {
+        return;
+    }
+
+    sleep(backoff).await;
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::{calculate_retry_delay, sleep_with_backoff};
+    use std::time::Duration;
+
+    #[test]
+    fn retry_delay_uses_linear_backoff() {
+        assert_eq!(
+            calculate_retry_delay(Duration::from_millis(50), 0),
+            Duration::ZERO
+        );
+        assert_eq!(
+            calculate_retry_delay(Duration::from_millis(50), 1),
+            Duration::from_millis(50)
+        );
+        assert_eq!(
+            calculate_retry_delay(Duration::from_millis(50), 2),
+            Duration::from_millis(100)
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn sleep_with_zero_backoff_returns_immediately() {
+        sleep_with_backoff(Duration::ZERO).await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn sleep_with_positive_backoff_awaits_duration() {
+        let duration = Duration::from_millis(250);
+        let start = tokio::time::Instant::now();
+        sleep_with_backoff(duration).await;
+        assert_eq!(tokio::time::Instant::now() - start, duration);
+    }
+}


### PR DESCRIPTION
## Summary
- split the Hyprland client adapter into dedicated `config`, `sync_ops`, and `listeners` modules while keeping the facade lean
- centralized retry/backoff helpers and added focused unit tests for the new utilities
- bumped the workspace version to 0.6.3 and documented the reorganization in the changelog

## Testing
- cargo +nightly fmt --
- cargo +1.90.0 clippy -- -D warnings *(fails: missing system dependency `xkbcommon` required by smithay-client-toolkit)*
- cargo +1.90.0 build --all-targets *(fails: missing system dependency `xkbcommon` required by smithay-client-toolkit)*
- cargo +1.90.0 test --all *(fails: missing system dependency `xkbcommon` required by smithay-client-toolkit)*
- cargo +1.90.0 doc --no-deps *(fails: missing system dependency `xkbcommon` required by smithay-client-toolkit)*
- cargo audit *(reports existing upstream unmaintained crate advisories)*
- cargo deny check *(fails: unable to fetch advisory database due to network restriction)*

------
https://chatgpt.com/codex/tasks/task_e_68d942ce9c88832b82b24e76d244bd88