### PR TITLE
Refactor privacy service listeners into modular components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.3] - 2025-09-28
+
+### Changed
+
+- Extract the PipeWire runtime and webcam watchers into dedicated modules, wiring
+  the privacy service through injectable traits for improved testability.
+- Reuse a shared privacy event publisher abstraction across the service and new
+  components while keeping data/state structures in the core module.
+
+### Added
+
+- Unit tests covering privacy updates from both PipeWire node events and
+  inotify-driven webcam notifications.
+
 
 ## [0.6.2] - 2025-09-28
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2265,7 +2265,7 @@ dependencies = [
 
 [[package]]
 name = "hydebar-app"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "clap",
  "flexi_logger",
@@ -2279,7 +2279,7 @@ dependencies = [
 
 [[package]]
 name = "hydebar-core"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2314,7 +2314,7 @@ dependencies = [
 
 [[package]]
 name = "hydebar-gui"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "flexi_logger",
  "hydebar-core",
@@ -2326,7 +2326,7 @@ dependencies = [
 
 [[package]]
 name = "hydebar-proto"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "hex_color",
  "iced",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.6.2"
+version = "0.6.3"
 edition = "2024"
 rust-version = "1.90"
 

--- a/crates/hydebar-core/src/services/privacy/inotify.rs
+++ b/crates/hydebar-core/src/services/privacy/inotify.rs
@@ -1,0 +1,88 @@
+use crate::services::privacy::{PrivacyError, PrivacyEvent, PrivacyStream};
+use iced::futures::StreamExt;
+use inotify::{EventMask, Inotify, WatchMask};
+use std::{
+    future::Future,
+    path::{Path, PathBuf},
+    pin::Pin,
+};
+
+/// Provides webcam state updates sourced from inotify events.
+pub(crate) trait WebcamEventSource {
+    /// Future returned when subscribing to webcam state notifications.
+    type Future<'a>: Future<Output = Result<PrivacyStream, PrivacyError>> + Send + 'a
+    where
+        Self: 'a;
+
+    /// Subscribe to webcam state notifications.
+    fn subscribe(&self) -> Self::Future<'_>;
+}
+
+/// Watches a webcam device path using the inotify subsystem.
+#[derive(Debug, Clone)]
+pub(crate) struct WebcamWatcher {
+    device_path: PathBuf,
+}
+
+impl WebcamWatcher {
+    /// Create a new watcher for the provided webcam device path.
+    pub(crate) fn new(path: &Path) -> Self {
+        Self {
+            device_path: path.into(),
+        }
+    }
+
+    async fn create_stream(&self) -> Result<PrivacyStream, PrivacyError> {
+        let inotify = Inotify::init().map_err(|err| PrivacyError::inotify_init(err.to_string()))?;
+        match inotify.watches().add(
+            &self.device_path,
+            WatchMask::CLOSE_WRITE
+                | WatchMask::CLOSE_NOWRITE
+                | WatchMask::DELETE_SELF
+                | WatchMask::OPEN
+                | WatchMask::ATTRIB,
+        ) {
+            Ok(_) => {}
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                return Err(PrivacyError::WebcamUnavailable);
+            }
+            Err(err) => {
+                return Err(PrivacyError::inotify_watch(err.to_string()));
+            }
+        }
+
+        let buffer = [0; 512];
+        let stream = inotify
+            .into_event_stream(buffer)
+            .map_err(|err| PrivacyError::inotify_init(err.to_string()))?
+            .filter_map(|event| async move {
+                match event {
+                    Ok(event) => match event.mask {
+                        EventMask::OPEN => Some(PrivacyEvent::WebcamOpen),
+                        EventMask::CLOSE_WRITE | EventMask::CLOSE_NOWRITE => {
+                            Some(PrivacyEvent::WebcamClose)
+                        }
+                        _ => None,
+                    },
+                    Err(error) => {
+                        log::warn!("Failed to read webcam event: {error}");
+                        None
+                    }
+                }
+            })
+            .boxed();
+
+        Ok(stream)
+    }
+}
+
+impl WebcamEventSource for WebcamWatcher {
+    type Future<'a>
+        = Pin<Box<dyn Future<Output = Result<PrivacyStream, PrivacyError>> + Send + 'a>>
+    where
+        Self: 'a;
+
+    fn subscribe(&self) -> Self::Future<'_> {
+        Box::pin(self.create_stream())
+    }
+}

--- a/crates/hydebar-core/src/services/privacy/pipewire.rs
+++ b/crates/hydebar-core/src/services/privacy/pipewire.rs
@@ -1,0 +1,147 @@
+use crate::services::privacy::{ApplicationNode, Media, PrivacyError, PrivacyEvent};
+use pipewire::{context::ContextRc, core::CoreRc, main_loop::MainLoopRc};
+use std::{future::Future, pin::Pin, thread};
+use tokio::sync::{
+    mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel},
+    oneshot,
+};
+
+/// Provides access to privacy events published by PipeWire.
+pub(crate) trait PipewireEventSource {
+    /// Future returned when subscribing to PipeWire notifications.
+    type Future<'a>: Future<Output = Result<UnboundedReceiver<PrivacyEvent>, PrivacyError>>
+        + Send
+        + 'a
+    where
+        Self: 'a;
+
+    /// Subscribe to PipeWire privacy notifications.
+    fn subscribe(&self) -> Self::Future<'_>;
+}
+
+/// Factory creating PipeWire-backed privacy event receivers.
+#[derive(Debug, Default, Clone, Copy)]
+pub(crate) struct PipewireListener;
+
+impl PipewireListener {
+    async fn create_receiver(&self) -> Result<UnboundedReceiver<PrivacyEvent>, PrivacyError> {
+        let (tx, rx) = unbounded_channel::<PrivacyEvent>();
+        let (init_tx, init_rx) = oneshot::channel::<Result<(), PrivacyError>>();
+
+        let builder = thread::Builder::new().name("privacy-pipewire".into());
+        builder
+            .spawn(move || {
+                struct PipewireRuntime {
+                    mainloop: MainLoopRc,
+                    _context: ContextRc,
+                    _core: CoreRc,
+                    _listener: pipewire::registry::Listener,
+                }
+
+                impl PipewireRuntime {
+                    fn new(tx: UnboundedSender<PrivacyEvent>) -> Result<Self, PrivacyError> {
+                        let mainloop = MainLoopRc::new(None)
+                            .map_err(|err| PrivacyError::pipewire_mainloop(err.to_string()))?;
+                        let context = ContextRc::new(&mainloop, None)
+                            .map_err(|err| PrivacyError::pipewire_context(err.to_string()))?;
+                        let core = context
+                            .connect_rc(None)
+                            .map_err(|err| PrivacyError::pipewire_core(err.to_string()))?;
+                        let registry = core
+                            .get_registry_rc()
+                            .map_err(|err| PrivacyError::pipewire_registry(err.to_string()))?;
+                        let remove_tx = tx.clone();
+                        let listener = registry
+                            .add_listener_local()
+                            .global({
+                                let tx = tx.clone();
+                                move |global| {
+                                    if let Some(props) = global.props {
+                                        if let Some(media) =
+                                            props.get("media.class").filter(|value| {
+                                                *value == "Stream/Input/Video"
+                                                    || *value == "Stream/Input/Audio"
+                                            })
+                                        {
+                                            let event = PrivacyEvent::AddNode(ApplicationNode {
+                                                id: global.id,
+                                                media: if media == "Stream/Input/Video" {
+                                                    Media::Video
+                                                } else {
+                                                    Media::Audio
+                                                },
+                                            });
+                                            if let Err(error) = tx.send(event) {
+                                                log::warn!(
+                                                    "Failed to forward PipeWire add event: {error}"
+                                                );
+                                            }
+                                        }
+                                    }
+                                }
+                            })
+                            .global_remove(move |id| {
+                                if let Err(error) = remove_tx.send(PrivacyEvent::RemoveNode(id)) {
+                                    log::warn!("Failed to forward PipeWire remove event: {error}");
+                                }
+                            })
+                            .register();
+
+                        Ok(Self {
+                            mainloop,
+                            _context: context,
+                            _core: core,
+                            _listener: listener,
+                        })
+                    }
+
+                    fn run(self) {
+                        self.mainloop.run();
+                    }
+                }
+
+                match PipewireRuntime::new(tx) {
+                    Ok(runtime) => {
+                        if init_tx.send(Ok(())).is_err() {
+                            log::warn!(
+                                "PipeWire initialisation receiver dropped before completion"
+                            );
+                            return;
+                        }
+                        runtime.run();
+                        log::warn!("PipeWire mainloop exited");
+                    }
+                    Err(error) => {
+                        log::error!("Failed to initialise PipeWire: {error}");
+                        if init_tx.send(Err(error.clone())).is_err() {
+                            log::warn!("Unable to report PipeWire initialisation failure: {error}");
+                        }
+                    }
+                }
+            })
+            .map_err(|err| {
+                PrivacyError::channel(format!("failed to spawn PipeWire listener thread: {err}"))
+            })?;
+
+        match init_rx.await {
+            Ok(Ok(())) => Ok(rx),
+            Ok(Err(err)) => Err(err),
+            Err(_) => Err(PrivacyError::channel(
+                "failed to receive PipeWire initialisation result",
+            )),
+        }
+    }
+}
+
+impl PipewireEventSource for PipewireListener {
+    type Future<'a>
+        = Pin<
+        Box<dyn Future<Output = Result<UnboundedReceiver<PrivacyEvent>, PrivacyError>> + Send + 'a>,
+    >
+    where
+        Self: 'a;
+
+    fn subscribe(&self) -> Self::Future<'_> {
+        Box::pin(self.create_receiver())
+    }
+}

--- a/crates/hydebar-core/src/services/privacy/publisher.rs
+++ b/crates/hydebar-core/src/services/privacy/publisher.rs
@@ -1,0 +1,33 @@
+use std::{future::Future, pin::Pin};
+
+use iced::futures::channel::mpsc::Sender;
+
+use crate::services::ServiceEvent;
+
+use super::{PrivacyError, PrivacyService};
+
+/// Sink used to publish privacy service events to interested consumers.
+pub trait PrivacyEventPublisher {
+    /// Future type returned when emitting a [`ServiceEvent`].
+    type SendFuture<'a>: Future<Output = Result<(), PrivacyError>> + Send + 'a
+    where
+        Self: 'a;
+
+    /// Publish a privacy service event to subscribers.
+    fn send(&mut self, event: ServiceEvent<PrivacyService>) -> Self::SendFuture<'_>;
+}
+
+impl PrivacyEventPublisher for Sender<ServiceEvent<PrivacyService>> {
+    type SendFuture<'a>
+        = Pin<Box<dyn Future<Output = Result<(), PrivacyError>> + Send + 'a>>
+    where
+        Self: 'a;
+
+    fn send(&mut self, event: ServiceEvent<PrivacyService>) -> Self::SendFuture<'_> {
+        Box::pin(async move {
+            self.send(event)
+                .await
+                .map_err(|error| PrivacyError::channel(error.to_string()))
+        })
+    }
+}


### PR DESCRIPTION
## Summary
- split the privacy service into pipewire and inotify listener modules behind traits for easier testing and substitution
- centralize the privacy event publisher abstraction and update the service to use the injected listeners with new end-to-end tests
- bump the workspace version to 0.6.3 and document the refactor in the changelog

## Testing
- `cargo +nightly fmt --`
- `cargo +1.90.0 build --all-targets` *(fails: missing system library xkbcommon required by smithay-client-toolkit)*
- `cargo +1.90.0 clippy -- -D warnings` *(fails: missing system library xkbcommon required by smithay-client-toolkit)*
- `cargo +1.90.0 test --all` *(fails: missing system library xkbcommon required by smithay-client-toolkit)*
- `cargo +1.90.0 doc --no-deps` *(fails: missing system library xkbcommon required by smithay-client-toolkit)*
- `cargo audit` *(reports existing upstream unmaintained crate advisories)*
- `cargo install cargo-deny` *(hangs during compilation; tool not available to run `cargo deny check`)*

------
https://chatgpt.com/codex/tasks/task_e_68d942e088d8832bb1047f8e179b549d