### PR TITLE
Refactor system info module structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.5] - 2025-09-30
+
+### Changed
+
+- Split the system information module into dedicated `data`, `runtime`, and
+  `view` components while keeping `system_info.rs` as a façade for
+  registration and type exports.
+- Centralised the polling task management inside the new runtime helper,
+  simplifying module orchestration and test coverage.
+
+### Added
+
+- Unit tests for the system information data sampler and indicator builders
+  covering sampling invariants and indicator selection edge cases.
+
 ## [0.6.4] - 2025-09-29
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2265,7 +2265,7 @@ dependencies = [
 
 [[package]]
 name = "hydebar-app"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "clap",
  "flexi_logger",
@@ -2279,7 +2279,7 @@ dependencies = [
 
 [[package]]
 name = "hydebar-core"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2314,7 +2314,7 @@ dependencies = [
 
 [[package]]
 name = "hydebar-gui"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "flexi_logger",
  "hydebar-core",
@@ -2326,7 +2326,7 @@ dependencies = [
 
 [[package]]
 name = "hydebar-proto"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "hex_color",
  "iced",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.6.4"
+version = "0.6.5"
 edition = "2024"
 rust-version = "1.90"
 

--- a/crates/hydebar-core/src/modules/system_info.rs
+++ b/crates/hydebar-core/src/modules/system_info.rs
@@ -1,305 +1,55 @@
-use crate::{
-    ModuleContext, ModuleEventSender, app,
-    components::icons::{Icons, icon},
-    config::{SystemIndicator, SystemModuleConfig},
-    event_bus::ModuleEvent,
-    menu::MenuType,
-};
-use iced::{
-    Alignment, Element, Length, Theme,
-    widget::{Column, Row, column, container, horizontal_rule, row, text},
-};
-use itertools::Itertools;
-use log::error;
-use std::time::{Duration, Instant};
-use sysinfo::{Components, Disks, Networks, System};
-use tokio::{
-    task::JoinHandle,
-    time::{MissedTickBehavior, interval},
-};
+mod data;
+mod runtime;
+mod view;
+
+pub use data::{NetworkData, SystemInfoData, SystemInfoSampler};
+pub use runtime::REFRESH_INTERVAL;
+pub use view::{build_indicator_view, build_menu_view, indicator_elements};
+
+use crate::{ModuleContext, app, config::SystemModuleConfig, event_bus::ModuleEvent};
+use iced::Element;
 
 use super::{Module, ModuleError, OnModulePress};
 
-const REFRESH_INTERVAL: Duration = Duration::from_secs(5);
-
-struct NetworkData {
-    ip: String,
-    download_speed: u32,
-    upload_speed: u32,
-    last_check: Instant,
-}
-
-struct SystemInfoData {
-    pub cpu_usage: u32,
-    pub memory_usage: u32,
-    pub memory_swap_usage: u32,
-    pub temperature: Option<i32>,
-    pub disks: Vec<(String, u32)>,
-    pub network: Option<NetworkData>,
-}
-
-fn get_system_info(
-    system: &mut System,
-    components: &mut Components,
-    disks: &mut Disks,
-    (networks, last_check): (&mut Networks, Option<Instant>),
-) -> SystemInfoData {
-    system.refresh_memory();
-    system.refresh_cpu_specifics(sysinfo::CpuRefreshKind::everything());
-
-    components.refresh(true);
-    disks.refresh(true);
-    networks.refresh(true);
-
-    let cpu_usage = system.global_cpu_usage().floor() as u32;
-    let memory_usage = ((system.total_memory() - system.available_memory()) as f32
-        / system.total_memory() as f32
-        * 100.) as u32;
-
-    let memory_swap_usage = ((system.total_swap() - system.free_swap()) as f32
-        / system.total_swap() as f32
-        * 100.) as u32;
-
-    let temperature = components
-        .iter()
-        .find(|c| c.label() == "acpitz temp1")
-        .and_then(|c| c.temperature().map(|t| t as i32));
-
-    let disks = disks
-        .into_iter()
-        .filter(|d| !d.is_removable() && d.total_space() != 0)
-        .map(|d| {
-            (
-                d.mount_point().to_string_lossy().to_string(),
-                (((d.total_space() - d.available_space()) as f32) / d.total_space() as f32 * 100.)
-                    as u32,
-            )
-        })
-        .sorted_by(|a, b| a.0.cmp(&b.0))
-        .collect::<Vec<_>>();
-
-    let elapsed = last_check.map(|v| v.elapsed().as_secs());
-
-    let network = networks.iter().fold(
-        (None, 0, 0),
-        |(first_ip, total_received, total_transmitted), (_, data)| {
-            let ip = first_ip.or_else(|| {
-                data.ip_networks()
-                    .iter()
-                    .sorted_by(|a, b| a.addr.cmp(&b.addr))
-                    .next()
-                    .map(|ip| ip.addr)
-            });
-
-            let received = data.received();
-            let transmitted = data.transmitted();
-
-            (
-                first_ip.or(ip),
-                total_received + received,
-                total_transmitted + transmitted,
-            )
-        },
-    );
-
-    let network_speed = |value: u64| {
-        match elapsed {
-            None | Some(0) => 0, // avoid division by zero
-            Some(elapsed) => (value / 1000) as u32 / elapsed as u32,
-        }
-    };
-
-    SystemInfoData {
-        cpu_usage,
-        memory_usage,
-        memory_swap_usage,
-        temperature,
-        disks,
-        network: network.0.map(|ip| NetworkData {
-            ip: ip.to_string(),
-            download_speed: network_speed(network.1),
-            upload_speed: network_speed(network.2),
-            last_check: Instant::now(),
-        }),
-    }
-}
-
-pub struct SystemInfo {
-    system: System,
-    components: Components,
-    disks: Disks,
-    networks: Networks,
-    data: SystemInfoData,
-    sender: Option<ModuleEventSender<Message>>,
-    polling_task: Option<JoinHandle<()>>,
-}
-
-impl Default for SystemInfo {
-    fn default() -> Self {
-        let mut system = System::new();
-        let mut components = Components::new_with_refreshed_list();
-        let mut disks = Disks::new_with_refreshed_list();
-        let mut networks = Networks::new_with_refreshed_list();
-        let data = get_system_info(
-            &mut system,
-            &mut components,
-            &mut disks,
-            (&mut networks, None),
-        );
-
-        Self {
-            system,
-            components,
-            disks,
-            data,
-            networks,
-            sender: None,
-            polling_task: None,
-        }
-    }
-}
-
+/// Messages published by the system information module.
 #[derive(Debug, Clone)]
 pub enum Message {
     Update,
 }
 
+/// Module responsible for sampling and presenting local system metrics.
+pub struct SystemInfo {
+    sampler: SystemInfoSampler,
+    data: SystemInfoData,
+    polling: runtime::PollingTask,
+}
+
+impl Default for SystemInfo {
+    fn default() -> Self {
+        let mut sampler = SystemInfoSampler::new();
+        let data = sampler.sample();
+
+        Self {
+            sampler,
+            data,
+            polling: runtime::PollingTask::new(),
+        }
+    }
+}
+
 impl SystemInfo {
+    /// React to module messages by updating cached metrics when necessary.
     pub fn update(&mut self, message: Message) {
         match message {
             Message::Update => {
-                self.data = get_system_info(
-                    &mut self.system,
-                    &mut self.components,
-                    &mut self.disks,
-                    (
-                        &mut self.networks,
-                        self.data.network.as_ref().map(|n| n.last_check),
-                    ),
-                );
+                self.data = self.sampler.sample();
             }
         }
     }
 
-    fn info_element<'a>(info_icon: Icons, label: String, value: String) -> Element<'a, Message> {
-        row!(
-            container(icon(info_icon).size(22)).center_x(Length::Fixed(32.)),
-            text(label).width(Length::Fill),
-            text(value)
-        )
-        .align_y(Alignment::Center)
-        .spacing(8)
-        .into()
-    }
-
-    fn indicator_info_element<'a, V: std::fmt::Display + PartialOrd + 'a>(
-        info_icon: Icons,
-        value: V,
-        unit: &str,
-        threshold: Option<(V, V)>,
-        prefix: Option<&str>,
-    ) -> Element<'a, app::Message> {
-        let element = container(
-            row!(
-                icon(info_icon),
-                if let Some(prefix) = prefix {
-                    text(format!("{prefix} {value}{unit}"))
-                } else {
-                    text(format!("{value}{unit}"))
-                }
-            )
-            .spacing(4),
-        );
-
-        if let Some((warn_threshold, alert_threshold)) = threshold {
-            element
-                .style(move |theme: &Theme| container::Style {
-                    text_color: if value > warn_threshold && value < alert_threshold {
-                        Some(theme.extended_palette().danger.weak.color)
-                    } else if value >= alert_threshold {
-                        Some(theme.palette().danger)
-                    } else {
-                        None
-                    },
-                    ..Default::default()
-                })
-                .into()
-        } else {
-            element.into()
-        }
-    }
-
+    /// Render the menu entry exposing detailed system information.
     pub fn menu_view(&self) -> Element<Message> {
-        column!(
-            text("System Info").size(20),
-            horizontal_rule(1),
-            Column::new()
-                .push(Self::info_element(
-                    Icons::Cpu,
-                    "CPU Usage".to_string(),
-                    format!("{}%", self.data.cpu_usage),
-                ))
-                .push(Self::info_element(
-                    Icons::Mem,
-                    "Memory Usage".to_string(),
-                    format!("{}%", self.data.memory_usage),
-                ))
-                .push(Self::info_element(
-                    Icons::Mem,
-                    "Swap memory Usage".to_string(),
-                    format!("{}%", self.data.memory_swap_usage),
-                ))
-                .push_maybe(self.data.temperature.map(|temp| {
-                    Self::info_element(Icons::Temp, "Temperature".to_string(), format!("{temp}°C"))
-                }))
-                .push(
-                    Column::with_children(
-                        self.data
-                            .disks
-                            .iter()
-                            .map(|(mount_point, usage)| {
-                                Self::info_element(
-                                    Icons::Drive,
-                                    format!("Disk Usage {mount_point}"),
-                                    format!("{usage}%"),
-                                )
-                            })
-                            .collect::<Vec<Element<_>>>(),
-                    )
-                    .spacing(4),
-                )
-                .push_maybe(self.data.network.as_ref().map(|network| {
-                    Column::with_children(vec![
-                        Self::info_element(
-                            Icons::IpAddress,
-                            "IP Address".to_string(),
-                            network.ip.clone(),
-                        ),
-                        Self::info_element(
-                            Icons::DownloadSpeed,
-                            "Download Speed".to_string(),
-                            if network.download_speed > 1000 {
-                                format!("{} MB/s", network.download_speed / 1000)
-                            } else {
-                                format!("{} KB/s", network.download_speed)
-                            },
-                        ),
-                        Self::info_element(
-                            Icons::UploadSpeed,
-                            "Upload Speed".to_string(),
-                            if network.upload_speed > 1000 {
-                                format!("{} MB/s", network.upload_speed / 1000)
-                            } else {
-                                format!("{} KB/s", network.upload_speed)
-                            },
-                        ),
-                    ])
-                }))
-                .spacing(4)
-                .padding([0, 8])
-        )
-        .spacing(8)
-        .into()
+        view::build_menu_view(&self.data)
     }
 }
 
@@ -312,30 +62,8 @@ impl Module for SystemInfo {
         ctx: &ModuleContext,
         _: Self::RegistrationData<'_>,
     ) -> Result<(), ModuleError> {
-        self.sender = Some(ctx.module_sender(ModuleEvent::SystemInfo));
-
-        if let Some(task) = self.polling_task.take() {
-            task.abort();
-        }
-
-        if let Some(sender) = self.sender.clone() {
-            let handle = ctx.runtime_handle().spawn(async move {
-                let mut ticker = interval(REFRESH_INTERVAL);
-                ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
-                // Discard the immediate first tick to align with the configured interval.
-                let _ = ticker.tick().await;
-
-                loop {
-                    ticker.tick().await;
-
-                    if let Err(err) = sender.try_send(Message::Update) {
-                        error!("failed to publish system info refresh: {err}");
-                    }
-                }
-            });
-
-            self.polling_task = Some(handle);
-        }
+        let sender = ctx.module_sender(ModuleEvent::SystemInfo);
+        self.polling.spawn(ctx, sender);
 
         Ok(())
     }
@@ -344,176 +72,6 @@ impl Module for SystemInfo {
         &self,
         config: Self::ViewData<'_>,
     ) -> Option<(Element<app::Message>, Option<OnModulePress>)> {
-        let indicators = config.indicators.iter().filter_map(|i| match i {
-            SystemIndicator::Cpu => Some(Self::indicator_info_element(
-                Icons::Cpu,
-                self.data.cpu_usage,
-                "%",
-                Some((config.cpu.warn_threshold, config.cpu.alert_threshold)),
-                None,
-            )),
-            SystemIndicator::Memory => Some(Self::indicator_info_element(
-                Icons::Mem,
-                self.data.memory_usage,
-                "%",
-                Some((config.memory.warn_threshold, config.memory.alert_threshold)),
-                None,
-            )),
-            SystemIndicator::MemorySwap => Some(Self::indicator_info_element(
-                Icons::Mem,
-                self.data.memory_swap_usage,
-                "%",
-                Some((config.memory.warn_threshold, config.memory.alert_threshold)),
-                Some("swap"),
-            )),
-            SystemIndicator::Temperature => self.data.temperature.map(|temperature| {
-                Self::indicator_info_element(
-                    Icons::Temp,
-                    temperature,
-                    "°C",
-                    Some((
-                        config.temperature.warn_threshold,
-                        config.temperature.alert_threshold,
-                    )),
-                    None,
-                )
-            }),
-            SystemIndicator::Disk(mount) => {
-                self.data.disks.iter().find_map(|(disk_mount, disk)| {
-                    if disk_mount == mount {
-                        Some(Self::indicator_info_element(
-                            Icons::Drive,
-                            *disk,
-                            "%",
-                            Some((config.disk.warn_threshold, config.disk.alert_threshold)),
-                            Some(disk_mount),
-                        ))
-                    } else {
-                        None
-                    }
-                })
-            }
-            SystemIndicator::IpAddress => self.data.network.as_ref().map(|network| {
-                Self::indicator_info_element(
-                    Icons::IpAddress,
-                    network.ip.to_string(),
-                    "",
-                    None,
-                    None,
-                )
-            }),
-            SystemIndicator::DownloadSpeed => self.data.network.as_ref().map(|network| {
-                Self::indicator_info_element(
-                    Icons::DownloadSpeed,
-                    if network.download_speed > 1000 {
-                        network.download_speed / 1000
-                    } else {
-                        network.download_speed
-                    },
-                    if network.download_speed > 1000 {
-                        "MB/s"
-                    } else {
-                        "KB/s"
-                    },
-                    None,
-                    None,
-                )
-            }),
-            SystemIndicator::UploadSpeed => self.data.network.as_ref().map(|network| {
-                Self::indicator_info_element(
-                    Icons::UploadSpeed,
-                    if network.upload_speed > 1000 {
-                        network.upload_speed / 1000
-                    } else {
-                        network.upload_speed
-                    },
-                    if network.upload_speed > 1000 {
-                        "MB/s"
-                    } else {
-                        "KB/s"
-                    },
-                    None,
-                    None,
-                )
-            }),
-        });
-
-        Some((
-            Row::with_children(indicators)
-                .align_y(Alignment::Center)
-                .spacing(4)
-                .into(),
-            Some(OnModulePress::ToggleMenu(MenuType::SystemInfo)),
-        ))
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::{
-        event_bus::{BusEvent, EventBus},
-        modules::Module,
-    };
-    use std::num::NonZeroUsize;
-    use tokio::{task::yield_now, time::advance};
-
-    fn module_context() -> (ModuleContext, EventBus) {
-        let bus = EventBus::new(NonZeroUsize::new(16).expect("non-zero capacity"));
-        let ctx = ModuleContext::new(bus.sender(), tokio::runtime::Handle::current());
-
-        (ctx, bus)
-    }
-
-    fn expect_system_info_update(event: Option<BusEvent>) {
-        match event {
-            Some(BusEvent::Module(ModuleEvent::SystemInfo(Message::Update))) => {}
-            other => panic!("unexpected event: {other:?}"),
-        }
-    }
-
-    #[tokio::test(start_paused = true)]
-    async fn schedules_periodic_refreshes() {
-        let (ctx, bus) = module_context();
-        let mut module = SystemInfo::default();
-        let mut receiver = bus.receiver();
-
-        module.register(&ctx, ()).expect("register system info");
-        yield_now().await;
-
-        assert!(receiver.try_recv().expect("initial queue state").is_none());
-
-        advance(REFRESH_INTERVAL).await;
-        yield_now().await;
-
-        let event = receiver.try_recv().expect("queued refresh after interval");
-        expect_system_info_update(event);
-    }
-
-    #[tokio::test(start_paused = true)]
-    async fn re_register_aborts_previous_task() {
-        let (ctx, bus) = module_context();
-        let mut module = SystemInfo::default();
-        let mut receiver = bus.receiver();
-
-        module.register(&ctx, ()).expect("register system info");
-        yield_now().await;
-
-        advance(REFRESH_INTERVAL).await;
-        yield_now().await;
-
-        let first = receiver.try_recv().expect("first refresh after interval");
-        expect_system_info_update(first);
-        assert!(receiver.try_recv().expect("drain first interval").is_none());
-
-        module.register(&ctx, ()).expect("re-register system info");
-        yield_now().await;
-
-        advance(REFRESH_INTERVAL).await;
-        yield_now().await;
-
-        let second = receiver.try_recv().expect("refresh after re-registration");
-        expect_system_info_update(second);
-        assert!(receiver.try_recv().expect("no duplicate refresh").is_none());
+        view::build_indicator_view(&self.data, config)
     }
 }

--- a/crates/hydebar-core/src/modules/system_info/data.rs
+++ b/crates/hydebar-core/src/modules/system_info/data.rs
@@ -1,0 +1,244 @@
+use std::time::Instant;
+
+use itertools::Itertools;
+use sysinfo::{Components, Disks, Networks, System};
+
+/// Snapshot of network utilisation metrics captured during sampling.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NetworkData {
+    pub ip: String,
+    pub download_speed: u32,
+    pub upload_speed: u32,
+    last_check: Instant,
+}
+
+impl NetworkData {
+    /// Create a new network metric snapshot with the provided parameters.
+    pub fn new(ip: String, download_speed: u32, upload_speed: u32, last_check: Instant) -> Self {
+        Self {
+            ip,
+            download_speed,
+            upload_speed,
+            last_check,
+        }
+    }
+
+    /// Instant when the underlying network totals were observed.
+    pub fn last_check(&self) -> Instant {
+        self.last_check
+    }
+}
+
+/// Aggregated system information consumed by the UI layer.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SystemInfoData {
+    pub cpu_usage: u32,
+    pub memory_usage: u32,
+    pub memory_swap_usage: u32,
+    pub temperature: Option<i32>,
+    pub disks: Vec<(String, u32)>,
+    pub network: Option<NetworkData>,
+}
+
+#[derive(Debug, Clone)]
+struct NetworkSnapshot {
+    ip: Option<String>,
+    total_received: u64,
+    total_transmitted: u64,
+    timestamp: Instant,
+}
+
+impl NetworkSnapshot {
+    fn capture(networks: &Networks, now: Instant) -> Option<Self> {
+        let (ip, total_received, total_transmitted) = networks.iter().fold(
+            (None, 0_u64, 0_u64),
+            |(first_ip, received, transmitted), (_, data)| {
+                let next_ip = first_ip.or_else(|| {
+                    data.ip_networks()
+                        .iter()
+                        .sorted_by(|a, b| a.addr.cmp(&b.addr))
+                        .next()
+                        .map(|ip| ip.addr.to_string())
+                });
+
+                (
+                    next_ip,
+                    received + data.received(),
+                    transmitted + data.transmitted(),
+                )
+            },
+        );
+
+        let ip = ip?;
+
+        Some(Self {
+            ip: Some(ip),
+            total_received,
+            total_transmitted,
+            timestamp: now,
+        })
+    }
+
+    fn into_data(&self, previous: Option<&NetworkSnapshot>) -> NetworkData {
+        let elapsed = previous
+            .map(|snapshot| self.timestamp.saturating_duration_since(snapshot.timestamp))
+            .unwrap_or_default();
+        let seconds = elapsed.as_secs();
+
+        let compute_speed = |current: u64, previous_total: u64| -> u32 {
+            if seconds == 0 {
+                return 0;
+            }
+
+            let delta = current.saturating_sub(previous_total);
+            ((delta / 1000) as u32) / (seconds as u32)
+        };
+
+        NetworkData {
+            ip: self.ip.clone().unwrap_or_else(|| "Unknown".to_string()),
+            download_speed: compute_speed(
+                self.total_received,
+                previous.map_or(0, |snapshot| snapshot.total_received),
+            ),
+            upload_speed: compute_speed(
+                self.total_transmitted,
+                previous.map_or(0, |snapshot| snapshot.total_transmitted),
+            ),
+            last_check: self.timestamp,
+        }
+    }
+}
+
+/// Samples system metrics using the [`sysinfo`] crate.
+#[derive(Debug)]
+pub struct SystemInfoSampler {
+    system: System,
+    components: Components,
+    disks: Disks,
+    networks: Networks,
+    last_network: Option<NetworkSnapshot>,
+}
+
+impl SystemInfoSampler {
+    /// Instantiate a sampler with refreshed sysinfo collections.
+    pub fn new() -> Self {
+        Self {
+            system: System::new(),
+            components: Components::new_with_refreshed_list(),
+            disks: Disks::new_with_refreshed_list(),
+            networks: Networks::new_with_refreshed_list(),
+            last_network: None,
+        }
+    }
+
+    /// Capture the latest system metrics, updating internal state for subsequent samples.
+    pub fn sample(&mut self) -> SystemInfoData {
+        self.system
+            .refresh_cpu_specifics(sysinfo::CpuRefreshKind::everything());
+        self.system.refresh_memory();
+        self.components.refresh(true);
+        self.disks.refresh(true);
+        self.networks.refresh(true);
+
+        let now = Instant::now();
+        let observation = NetworkSnapshot::capture(&self.networks, now);
+        let network = observation
+            .as_ref()
+            .map(|snapshot| snapshot.into_data(self.last_network.as_ref()));
+        self.last_network = observation;
+
+        let cpu_usage = self.system.global_cpu_usage().floor() as u32;
+        let memory_usage = percentage(
+            self.system
+                .total_memory()
+                .saturating_sub(self.system.available_memory()),
+            self.system.total_memory(),
+        );
+        let memory_swap_usage = percentage(
+            self.system
+                .total_swap()
+                .saturating_sub(self.system.free_swap()),
+            self.system.total_swap(),
+        );
+
+        let temperature = self
+            .components
+            .iter()
+            .find(|component| component.label() == "acpitz temp1")
+            .and_then(|component| component.temperature().map(|value| value as i32));
+
+        let disks = self
+            .disks
+            .iter()
+            .filter(|disk| !disk.is_removable() && disk.total_space() != 0)
+            .map(|disk| {
+                let mount_point = disk.mount_point().to_string_lossy().to_string();
+                let usage = percentage(
+                    disk.total_space().saturating_sub(disk.available_space()),
+                    disk.total_space(),
+                );
+
+                (mount_point, usage)
+            })
+            .sorted_by(|a, b| a.0.cmp(&b.0))
+            .collect();
+
+        SystemInfoData {
+            cpu_usage,
+            memory_usage,
+            memory_swap_usage,
+            temperature,
+            disks,
+            network,
+        }
+    }
+}
+
+fn percentage(used: u64, total: u64) -> u32 {
+    if total == 0 {
+        return 0;
+    }
+
+    ((used as f32 / total as f32) * 100.) as u32
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn snapshot_speed_zero_when_no_elapsed() {
+        let timestamp = Instant::now();
+        let previous = NetworkSnapshot {
+            ip: Some("127.0.0.1".to_string()),
+            total_received: 1024,
+            total_transmitted: 2048,
+            timestamp,
+        };
+        let snapshot = NetworkSnapshot {
+            ip: Some("127.0.0.1".to_string()),
+            total_received: 2048,
+            total_transmitted: 4096,
+            timestamp,
+        };
+
+        let data = snapshot.into_data(Some(&previous));
+
+        assert_eq!(data.download_speed, 0);
+        assert_eq!(data.upload_speed, 0);
+    }
+
+    #[test]
+    fn percentage_handles_zero_total() {
+        assert_eq!(percentage(5, 0), 0);
+    }
+
+    #[test]
+    fn sampler_produces_data() {
+        let mut sampler = SystemInfoSampler::new();
+        let data = sampler.sample();
+
+        assert!(data.cpu_usage <= 100);
+        assert!(data.memory_usage <= 100);
+        assert!(data.memory_swap_usage <= 100);
+    }
+}

--- a/crates/hydebar-core/src/modules/system_info/runtime.rs
+++ b/crates/hydebar-core/src/modules/system_info/runtime.rs
@@ -1,0 +1,135 @@
+use std::time::Duration;
+
+use log::error;
+use tokio::{
+    task::JoinHandle,
+    time::{MissedTickBehavior, interval},
+};
+
+use crate::{ModuleContext, ModuleEventSender};
+
+use super::Message;
+
+/// Interval between system information refresh ticks.
+pub const REFRESH_INTERVAL: Duration = Duration::from_secs(5);
+
+/// Manages the background polling task responsible for refreshing system metrics.
+#[derive(Default)]
+pub struct PollingTask {
+    handle: Option<JoinHandle<()>>,
+}
+
+impl PollingTask {
+    /// Create a new polling task manager with no active background work.
+    pub fn new() -> Self {
+        Self { handle: None }
+    }
+
+    /// Abort any in-flight polling task.
+    pub fn abort(&mut self) {
+        if let Some(handle) = self.handle.take() {
+            handle.abort();
+        }
+    }
+
+    /// Spawn a periodic refresh loop bound to the provided runtime context.
+    pub fn spawn(&mut self, ctx: &ModuleContext, sender: ModuleEventSender<Message>) {
+        self.abort();
+
+        let handle = ctx.runtime_handle().spawn(async move {
+            let mut ticker = interval(REFRESH_INTERVAL);
+            ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
+            let _ = ticker.tick().await;
+
+            loop {
+                ticker.tick().await;
+
+                if let Err(err) = sender.try_send(Message::Update) {
+                    error!("failed to publish system info refresh: {err}");
+                }
+            }
+        });
+
+        self.handle = Some(handle);
+    }
+}
+
+impl Drop for PollingTask {
+    fn drop(&mut self) {
+        self.abort();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        ModuleContext,
+        event_bus::{BusEvent, EventBus, ModuleEvent},
+        modules::system_info::Message,
+    };
+    use std::num::NonZeroUsize;
+    use tokio::{task::yield_now, time::advance};
+
+    fn module_context() -> (ModuleContext, EventBus) {
+        let capacity = NonZeroUsize::new(16).expect("non-zero capacity");
+        let bus = EventBus::new(capacity);
+        let ctx = ModuleContext::new(bus.sender(), tokio::runtime::Handle::current());
+
+        (ctx, bus)
+    }
+
+    fn expect_system_info_update(event: Option<BusEvent>) {
+        match event {
+            Some(BusEvent::Module(ModuleEvent::SystemInfo(Message::Update))) => {}
+            other => panic!("unexpected event: {other:?}"),
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn schedules_periodic_refreshes() {
+        let (ctx, bus) = module_context();
+        let mut polling = PollingTask::default();
+        let mut receiver = bus.receiver();
+
+        let sender = ctx.module_sender(ModuleEvent::SystemInfo);
+        polling.spawn(&ctx, sender);
+        yield_now().await;
+
+        assert!(receiver.try_recv().expect("initial queue state").is_none());
+
+        advance(REFRESH_INTERVAL).await;
+        yield_now().await;
+
+        let event = receiver.try_recv().expect("queued refresh after interval");
+        expect_system_info_update(event);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn respawn_replaces_previous_task() {
+        let (ctx, bus) = module_context();
+        let mut polling = PollingTask::default();
+        let mut receiver = bus.receiver();
+
+        let sender = ctx.module_sender(ModuleEvent::SystemInfo);
+        polling.spawn(&ctx, sender.clone());
+        yield_now().await;
+
+        advance(REFRESH_INTERVAL).await;
+        yield_now().await;
+
+        let first = receiver.try_recv().expect("first refresh after interval");
+        expect_system_info_update(first);
+        assert!(receiver.try_recv().expect("drain first interval").is_none());
+
+        polling.spawn(&ctx, sender);
+        yield_now().await;
+
+        advance(REFRESH_INTERVAL).await;
+        yield_now().await;
+
+        let second = receiver.try_recv().expect("refresh after respawn");
+        expect_system_info_update(second);
+        assert!(receiver.try_recv().expect("no duplicate refresh").is_none());
+    }
+}

--- a/crates/hydebar-core/src/modules/system_info/view.rs
+++ b/crates/hydebar-core/src/modules/system_info/view.rs
@@ -1,0 +1,286 @@
+use crate::{
+    app,
+    components::icons::{Icons, icon},
+    config::{SystemIndicator, SystemModuleConfig},
+    menu::MenuType,
+    modules::OnModulePress,
+};
+use iced::{
+    Alignment, Element, Length, Theme,
+    widget::{Column, Row, column, container, horizontal_rule, row, text},
+};
+
+use super::{Message, data::SystemInfoData};
+
+fn info_element<'a>(info_icon: Icons, label: &str, value: String) -> Element<'a, Message> {
+    row!(
+        container(icon(info_icon).size(22)).center_x(Length::Fixed(32.)),
+        text(label).width(Length::Fill),
+        text(value)
+    )
+    .align_y(Alignment::Center)
+    .spacing(8)
+    .into()
+}
+
+fn indicator_info_element<'a, V>(
+    info_icon: Icons,
+    value: V,
+    unit: &str,
+    threshold: Option<(V, V)>,
+    prefix: Option<&str>,
+) -> Element<'a, app::Message>
+where
+    V: std::fmt::Display + PartialOrd + Copy + 'a,
+{
+    let content = container(
+        row!(
+            icon(info_icon),
+            if let Some(prefix) = prefix {
+                text(format!("{prefix} {value}{unit}"))
+            } else {
+                text(format!("{value}{unit}"))
+            }
+        )
+        .spacing(4),
+    );
+
+    if let Some((warn_threshold, alert_threshold)) = threshold {
+        content
+            .style(move |theme: &Theme| container::Style {
+                text_color: if value > warn_threshold && value < alert_threshold {
+                    Some(theme.extended_palette().danger.weak.color)
+                } else if value >= alert_threshold {
+                    Some(theme.palette().danger)
+                } else {
+                    None
+                },
+                ..Default::default()
+            })
+            .into()
+    } else {
+        content.into()
+    }
+}
+
+fn format_speed(speed: u32) -> (u32, &'static str) {
+    if speed > 1000 {
+        (speed / 1000, "MB/s")
+    } else {
+        (speed, "KB/s")
+    }
+}
+
+/// Render the module menu displaying detailed system metrics.
+pub fn build_menu_view(data: &SystemInfoData) -> Element<Message> {
+    column![
+        text("System Info").size(20),
+        horizontal_rule(1),
+        Column::new()
+            .push(info_element(
+                Icons::Cpu,
+                "CPU Usage",
+                format!("{}%", data.cpu_usage)
+            ))
+            .push(info_element(
+                Icons::Mem,
+                "Memory Usage",
+                format!("{}%", data.memory_usage)
+            ))
+            .push(info_element(
+                Icons::Mem,
+                "Swap memory Usage",
+                format!("{}%", data.memory_swap_usage),
+            ))
+            .push_maybe(
+                data.temperature
+                    .map(|temp| { info_element(Icons::Temp, "Temperature", format!("{temp}°C")) })
+            )
+            .push(
+                Column::with_children(
+                    data.disks
+                        .iter()
+                        .map(|(mount_point, usage)| {
+                            info_element(
+                                Icons::Drive,
+                                &format!("Disk Usage {mount_point}"),
+                                format!("{usage}%"),
+                            )
+                        })
+                        .collect::<Vec<Element<_>>>(),
+                )
+                .spacing(4),
+            )
+            .push_maybe(data.network.as_ref().map(|network| {
+                let (download_value, download_unit) = format_speed(network.download_speed);
+                let (upload_value, upload_unit) = format_speed(network.upload_speed);
+
+                Column::with_children(vec![
+                    info_element(Icons::IpAddress, "IP Address", network.ip.clone()),
+                    info_element(
+                        Icons::DownloadSpeed,
+                        "Download Speed",
+                        format!("{download_value} {download_unit}"),
+                    ),
+                    info_element(
+                        Icons::UploadSpeed,
+                        "Upload Speed",
+                        format!("{upload_value} {upload_unit}"),
+                    ),
+                ])
+            }))
+            .spacing(4)
+            .padding([0, 8])
+    ]
+    .spacing(8)
+    .into()
+}
+
+/// Build the indicator widgets representing the configured subset of metrics.
+pub fn indicator_elements(
+    data: &SystemInfoData,
+    config: &SystemModuleConfig,
+) -> Vec<Element<app::Message>> {
+    config
+        .indicators
+        .iter()
+        .filter_map(|indicator| match indicator {
+            SystemIndicator::Cpu => Some(indicator_info_element(
+                Icons::Cpu,
+                data.cpu_usage,
+                "%",
+                Some((config.cpu.warn_threshold, config.cpu.alert_threshold)),
+                None,
+            )),
+            SystemIndicator::Memory => Some(indicator_info_element(
+                Icons::Mem,
+                data.memory_usage,
+                "%",
+                Some((config.memory.warn_threshold, config.memory.alert_threshold)),
+                None,
+            )),
+            SystemIndicator::MemorySwap => Some(indicator_info_element(
+                Icons::Mem,
+                data.memory_swap_usage,
+                "%",
+                Some((config.memory.warn_threshold, config.memory.alert_threshold)),
+                Some("swap"),
+            )),
+            SystemIndicator::Temperature => data.temperature.map(|temperature| {
+                indicator_info_element(
+                    Icons::Temp,
+                    temperature,
+                    "°C",
+                    Some((
+                        config.temperature.warn_threshold,
+                        config.temperature.alert_threshold,
+                    )),
+                    None,
+                )
+            }),
+            SystemIndicator::Disk(mount) => data.disks.iter().find_map(|(disk_mount, disk)| {
+                if disk_mount == mount {
+                    Some(indicator_info_element(
+                        Icons::Drive,
+                        *disk,
+                        "%",
+                        Some((config.disk.warn_threshold, config.disk.alert_threshold)),
+                        Some(disk_mount.as_str()),
+                    ))
+                } else {
+                    None
+                }
+            }),
+            SystemIndicator::IpAddress => data.network.as_ref().map(|network| {
+                indicator_info_element(Icons::IpAddress, network.ip.as_str(), "", None, None)
+            }),
+            SystemIndicator::DownloadSpeed => data.network.as_ref().map(|network| {
+                let (value, unit) = format_speed(network.download_speed);
+                indicator_info_element(Icons::DownloadSpeed, value, unit, None, None)
+            }),
+            SystemIndicator::UploadSpeed => data.network.as_ref().map(|network| {
+                let (value, unit) = format_speed(network.upload_speed);
+                indicator_info_element(Icons::UploadSpeed, value, unit, None, None)
+            }),
+        })
+        .collect()
+}
+
+/// Construct the condensed indicator row shown in the module section.
+pub fn build_indicator_view(
+    data: &SystemInfoData,
+    config: &SystemModuleConfig,
+) -> Option<(Element<app::Message>, Option<OnModulePress>)> {
+    let indicators = indicator_elements(data, config);
+
+    Some((
+        Row::with_children(indicators)
+            .align_y(Alignment::Center)
+            .spacing(4)
+            .into(),
+        Some(OnModulePress::ToggleMenu(MenuType::SystemInfo)),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{DiskIndicatorConfig, MemoryIndicatorConfig, TemperatureIndicatorConfig};
+
+    fn data_fixture() -> SystemInfoData {
+        SystemInfoData {
+            cpu_usage: 25,
+            memory_usage: 50,
+            memory_swap_usage: 10,
+            temperature: Some(42),
+            disks: vec![("/".to_string(), 60)],
+            network: None,
+        }
+    }
+
+    #[test]
+    fn indicator_row_contains_configured_entries() {
+        let data = data_fixture();
+        let config = SystemModuleConfig {
+            indicators: vec![SystemIndicator::Cpu, SystemIndicator::Memory],
+            cpu: Default::default(),
+            memory: MemoryIndicatorConfig {
+                warn_threshold: 70,
+                alert_threshold: 90,
+            },
+            temperature: TemperatureIndicatorConfig {
+                warn_threshold: 70,
+                alert_threshold: 90,
+            },
+            disk: Default::default(),
+        };
+
+        let indicators = indicator_elements(&data, &config);
+        assert_eq!(indicators.len(), 2);
+    }
+
+    #[test]
+    fn indicator_elements_include_network_entries_when_available() {
+        let mut data = data_fixture();
+        data.network = Some(crate::modules::system_info::NetworkData::new(
+            "127.0.0.1".to_string(),
+            2048,
+            1024,
+            std::time::Instant::now(),
+        ));
+
+        let config = SystemModuleConfig {
+            indicators: vec![SystemIndicator::IpAddress, SystemIndicator::DownloadSpeed],
+            ..SystemModuleConfig::default()
+        };
+
+        let indicators = indicator_elements(&data, &config);
+        assert_eq!(indicators.len(), 2);
+    }
+
+    #[test]
+    fn format_speed_converts_large_values_to_megabytes() {
+        let (value, unit) = format_speed(2048);
+        assert_eq!((value, unit), (2, "MB/s"));
+    }
+}


### PR DESCRIPTION
## Summary
- extract the system information sampler and network helpers into `modules/system_info/data.rs`, keeping a clean façade in `system_info.rs`
- add `modules/system_info/view.rs` for menu and indicator builders, plus unit tests covering indicator selection and formatting
- move the polling task into `modules/system_info/runtime.rs`, simplify registration, and bump the workspace version with a changelog entry

## Testing
- `cargo +nightly fmt --`
- `cargo +1.90.0 build --all-targets` *(fails: existing compilation errors in unrelated crates)*
- `cargo +1.90.0 test --all` *(fails: existing compilation errors in unrelated crates)*
- `cargo audit`


------
https://chatgpt.com/codex/tasks/task_e_68d9cefe4a38832b9c3efda2fea05d1d