### PR TITLE
Refactor tray service into helper modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.7] - 2025-10-02
+
+### Changed
+
+- Split the tray service into dedicated `icon` and `watcher` helpers while
+  keeping `tray.rs` focused on `TrayService` types and trait implementations.
+- Updated the watcher state machine to use typed errors and helper modules,
+  preserving the façade imports used by menu consumers.
+
+### Added
+
+- Unit tests covering icon lookup fallback logic and watcher error handling to
+  ensure resilient behaviour when themes or D-Bus signals fail.
 ## [0.6.6] - 2025-10-01
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2265,7 +2265,7 @@ dependencies = [
 
 [[package]]
 name = "hydebar-app"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "clap",
  "flexi_logger",
@@ -2279,7 +2279,7 @@ dependencies = [
 
 [[package]]
 name = "hydebar-core"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2314,7 +2314,7 @@ dependencies = [
 
 [[package]]
 name = "hydebar-gui"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "flexi_logger",
  "hydebar-core",
@@ -2326,7 +2326,7 @@ dependencies = [
 
 [[package]]
 name = "hydebar-proto"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "hex_color",
  "iced",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.6.6"
+version = "0.6.7"
 edition = "2024"
 rust-version = "1.90"
 

--- a/crates/hydebar-core/src/services/tray/icon.rs
+++ b/crates/hydebar-core/src/services/tray/icon.rs
@@ -1,0 +1,126 @@
+use std::path::PathBuf;
+
+use freedesktop_icons::lookup;
+use iced::widget::{image, svg};
+use linicon_theme::get_icon_theme;
+use log::{debug, trace};
+
+use super::{TrayIcon, dbus::Icon};
+
+pub(crate) fn icon_from_pixmaps(mut pixmaps: Vec<Icon>) -> Option<TrayIcon> {
+    pixmaps
+        .into_iter()
+        .max_by_key(|icon| {
+            trace!("tray icon w {}, h {}", icon.width, icon.height);
+            (icon.width, icon.height)
+        })
+        .map(|mut icon| {
+            for pixel in icon.bytes.chunks_exact_mut(4) {
+                pixel.rotate_left(1);
+            }
+
+            TrayIcon::Image(image::Handle::from_rgba(
+                icon.width as u32,
+                icon.height as u32,
+                icon.bytes,
+            ))
+        })
+}
+
+pub(crate) fn icon_from_name(icon_name: &str) -> Option<TrayIcon> {
+    debug!("resolving icon from name {icon_name}");
+
+    let lookup = lookup(icon_name).with_cache();
+    let theme = get_icon_theme();
+    if let Some(theme_name) = &theme {
+        debug!("icon theme found {theme_name}");
+    }
+
+    let icon_path = icon_path_with_theme_fallback(
+        theme,
+        |theme_name| lookup.with_theme(theme_name).find(),
+        || lookup.find(),
+    )?;
+
+    if icon_path.extension().is_some_and(|ext| ext == "svg") {
+        Some(TrayIcon::Svg(svg::Handle::from_path(icon_path)))
+    } else {
+        Some(TrayIcon::Image(image::Handle::from_path(icon_path)))
+    }
+}
+
+fn icon_path_with_theme_fallback<F, G>(
+    theme: Option<String>,
+    mut themed_lookup: F,
+    mut default_lookup: G,
+) -> Option<PathBuf>
+where
+    F: FnMut(&str) -> Option<PathBuf>,
+    G: FnMut() -> Option<PathBuf>,
+{
+    if let Some(theme_name) = theme.as_deref() {
+        if let Some(path) = themed_lookup(theme_name) {
+            return Some(path);
+        }
+    }
+
+    default_lookup()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        path::PathBuf,
+        sync::atomic::{AtomicUsize, Ordering},
+    };
+
+    use super::icon_path_with_theme_fallback;
+
+    #[test]
+    fn uses_theme_when_available() {
+        let theme_calls = AtomicUsize::new(0);
+        let default_calls = AtomicUsize::new(0);
+
+        let expected = PathBuf::from("/tmp/themed.svg");
+
+        let result = icon_path_with_theme_fallback(
+            Some(String::from("test")),
+            |_| {
+                theme_calls.fetch_add(1, Ordering::Relaxed);
+                Some(expected.clone())
+            },
+            || {
+                default_calls.fetch_add(1, Ordering::Relaxed);
+                Some(PathBuf::from("/tmp/default.svg"))
+            },
+        );
+
+        assert_eq!(theme_calls.load(Ordering::Relaxed), 1);
+        assert_eq!(default_calls.load(Ordering::Relaxed), 0);
+        assert_eq!(result.as_deref(), Some(expected.as_path()));
+    }
+
+    #[test]
+    fn falls_back_to_default_when_theme_missing() {
+        let theme_calls = AtomicUsize::new(0);
+        let default_calls = AtomicUsize::new(0);
+
+        let expected = PathBuf::from("/tmp/default.svg");
+
+        let result = icon_path_with_theme_fallback(
+            Some(String::from("test")),
+            |_| {
+                theme_calls.fetch_add(1, Ordering::Relaxed);
+                None
+            },
+            || {
+                default_calls.fetch_add(1, Ordering::Relaxed);
+                Some(expected.clone())
+            },
+        );
+
+        assert_eq!(theme_calls.load(Ordering::Relaxed), 1);
+        assert_eq!(default_calls.load(Ordering::Relaxed), 1);
+        assert_eq!(result.as_deref(), Some(expected.as_path()));
+    }
+}

--- a/crates/hydebar-core/src/services/tray/watcher.rs
+++ b/crates/hydebar-core/src/services/tray/watcher.rs
@@ -1,0 +1,281 @@
+use std::{future::Future, pin::Pin};
+
+use anyhow::Error;
+use iced::futures::{Stream, StreamExt, stream::select_all, stream_select};
+use log::{debug, error, info};
+use thiserror::Error;
+use tokio::future::pending;
+
+use crate::services::ServiceEvent;
+
+use super::{
+    StatusNotifierItem, TrayData, TrayEvent, TrayService,
+    dbus::{StatusNotifierWatcher, StatusNotifierWatcherProxy},
+    icon,
+};
+
+pub(crate) type TrayEventStream = Pin<Box<dyn Stream<Item = TrayEvent> + Send + 'static>>;
+
+#[derive(Debug, Error)]
+pub enum TrayWatcherError {
+    #[error("failed to connect to system bus: {0}")]
+    Connection(#[source] Error),
+    #[error("failed to initialise tray service: {0}")]
+    Initialization(#[source] Error),
+    #[error("failed to listen for tray events: {0}")]
+    EventStream(#[source] Error),
+}
+
+pub(crate) async fn initialize_data(conn: &zbus::Connection) -> Result<TrayData, TrayWatcherError> {
+    debug!("initializing tray data");
+    let proxy = StatusNotifierWatcherProxy::new(conn)
+        .await
+        .map_err(|err| TrayWatcherError::Initialization(err.into()))?;
+
+    let items = proxy
+        .registered_status_notifier_items()
+        .await
+        .map_err(|err| TrayWatcherError::Initialization(err.into()))?;
+
+    let mut status_items = Vec::with_capacity(items.len());
+    for item in items {
+        let item = StatusNotifierItem::new(conn, item)
+            .await
+            .map_err(TrayWatcherError::Initialization)?;
+        status_items.push(item);
+    }
+
+    debug!("created items: {status_items:?}");
+
+    Ok(TrayData(status_items))
+}
+
+pub(crate) async fn events(conn: &zbus::Connection) -> Result<TrayEventStream, TrayWatcherError> {
+    let watcher = StatusNotifierWatcherProxy::new(conn)
+        .await
+        .map_err(|err| TrayWatcherError::EventStream(err.into()))?;
+
+    let registered = watcher
+        .receive_status_notifier_item_registered()
+        .await
+        .map_err(|err| TrayWatcherError::EventStream(err.into()))?
+        .filter_map({
+            let conn = conn.clone();
+            move |event| {
+                let conn = conn.clone();
+                async move {
+                    debug!("registered {event:?}");
+                    match event.args() {
+                        Ok(args) => {
+                            let item =
+                                StatusNotifierItem::new(&conn, args.service.to_string()).await;
+                            item.map(TrayEvent::Registered).ok()
+                        }
+                        _ => None,
+                    }
+                }
+            }
+        })
+        .boxed();
+
+    let unregistered = watcher
+        .receive_status_notifier_item_unregistered()
+        .await
+        .map_err(|err| TrayWatcherError::EventStream(err.into()))?
+        .filter_map(|event| async move {
+            debug!("unregistered {event:?}");
+            match event.args() {
+                Ok(args) => Some(TrayEvent::Unregistered(args.service.to_string())),
+                _ => None,
+            }
+        })
+        .boxed();
+
+    let items = watcher
+        .registered_status_notifier_items()
+        .await
+        .map_err(|err| TrayWatcherError::EventStream(err.into()))?;
+
+    let mut icon_pixel_change = Vec::with_capacity(items.len());
+    let mut icon_name_change = Vec::with_capacity(items.len());
+    let mut menu_layout_change = Vec::with_capacity(items.len());
+
+    for name in items {
+        let item = StatusNotifierItem::new(conn, name.to_string())
+            .await
+            .map_err(TrayWatcherError::EventStream)?;
+
+        if let Ok(stream) = item.item_proxy.receive_icon_pixmap_changed().await {
+            icon_pixel_change.push(
+                stream
+                    .filter_map({
+                        let name = name.clone();
+                        move |icon| {
+                            let name = name.clone();
+                            async move {
+                                icon.get()
+                                    .await
+                                    .ok()
+                                    .and_then(icon::icon_from_pixmaps)
+                                    .map(|icon| TrayEvent::IconChanged(name.to_owned(), icon))
+                            }
+                        }
+                    })
+                    .boxed(),
+            );
+        }
+
+        if let Ok(stream) = item.item_proxy.receive_icon_name_changed().await {
+            icon_name_change.push(
+                stream
+                    .filter_map({
+                        let name = name.clone();
+                        move |icon_name| {
+                            let name = name.clone();
+                            async move {
+                                icon_name
+                                    .get()
+                                    .await
+                                    .ok()
+                                    .as_deref()
+                                    .and_then(icon::icon_from_name)
+                                    .map(|icon| TrayEvent::IconChanged(name.to_owned(), icon))
+                            }
+                        }
+                    })
+                    .boxed(),
+            );
+        }
+
+        if let Ok(layout_updated) = item.menu_proxy.receive_layout_updated().await {
+            menu_layout_change.push(
+                layout_updated
+                    .filter_map({
+                        let name = name.clone();
+                        let menu_proxy = item.menu_proxy.clone();
+                        move |_| {
+                            debug!("layout update event name {name}");
+                            let name = name.clone();
+                            let menu_proxy = menu_proxy.clone();
+                            async move {
+                                menu_proxy
+                                    .get_layout(0, -1, &[])
+                                    .await
+                                    .ok()
+                                    .map(|(_, layout)| {
+                                        TrayEvent::MenuLayoutChanged(name.to_owned(), layout)
+                                    })
+                            }
+                        }
+                    })
+                    .boxed(),
+            );
+        }
+    }
+
+    Ok(stream_select!(
+        registered,
+        unregistered,
+        select_all(icon_pixel_change),
+        select_all(icon_name_change),
+        select_all(menu_layout_change)
+    )
+    .boxed())
+}
+
+pub(crate) async fn start_listening<F, Fut>(mut publisher: F)
+where
+    F: FnMut(ServiceEvent<TrayService>) -> Fut + Send,
+    Fut: Future<Output = ()> + Send,
+{
+    let mut state = State::Init;
+
+    loop {
+        state = drive_state(state, &mut publisher).await;
+    }
+}
+
+enum State {
+    Init,
+    Active(zbus::Connection),
+    Error,
+}
+
+async fn drive_state<F, Fut>(state: State, publisher: &mut F) -> State
+where
+    F: FnMut(ServiceEvent<TrayService>) -> Fut + Send,
+    Fut: Future<Output = ()> + Send,
+{
+    match state {
+        State::Init => match StatusNotifierWatcher::start_server().await {
+            Ok(conn) => match initialize_data(&conn).await {
+                Ok(data) => {
+                    info!("Tray service initialized");
+
+                    publisher(ServiceEvent::Init(TrayService {
+                        data,
+                        _conn: conn.clone(),
+                    }))
+                    .await;
+
+                    State::Active(conn)
+                }
+                Err(err) => transition_to_error(err),
+            },
+            Err(err) => transition_to_error(TrayWatcherError::Connection(err.into())),
+        },
+        State::Active(conn) => {
+            info!("Listening for tray events");
+
+            match events(&conn).await {
+                Ok(mut stream) => {
+                    while let Some(event) = stream.next().await {
+                        debug!("tray data {event:?}");
+
+                        let reload_events = matches!(event, TrayEvent::Registered(_));
+
+                        publisher(ServiceEvent::Update(event)).await;
+
+                        if reload_events {
+                            break;
+                        }
+                    }
+
+                    State::Active(conn)
+                }
+                Err(err) => transition_to_error(err),
+            }
+        }
+        State::Error => {
+            error!("Tray service error");
+
+            pending::<()>().await;
+            State::Error
+        }
+    }
+}
+
+fn transition_to_error(error: TrayWatcherError) -> State {
+    error!("{error}");
+    State::Error
+}
+
+#[cfg(test)]
+mod tests {
+    use anyhow::anyhow;
+
+    use super::{State, TrayWatcherError, transition_to_error};
+
+    #[test]
+    fn transition_sets_error_state() {
+        let state = transition_to_error(TrayWatcherError::Connection(anyhow!("boom")));
+        assert!(matches!(state, State::Error));
+    }
+
+    #[test]
+    fn error_variants_have_context() {
+        let error = TrayWatcherError::EventStream(anyhow!("failure"));
+        let message = format!("{error}");
+        assert!(message.contains("failed to listen"));
+    }
+}


### PR DESCRIPTION
## Summary
- split the tray service into dedicated `icon` and `watcher` helpers while keeping `tray.rs` focused on `TrayService`
- introduce typed watcher errors and delegate the D-Bus state machine to the new helper, preserving the public façade
- add targeted unit tests for icon fallback logic and watcher error handling and bump the workspace version with changelog entry

## Testing
- `cargo +nightly fmt --`
- `cargo +nightly build --all-targets` *(fails: missing system library libxkbcommon)*
- `cargo +nightly test --all` *(fails: missing system library libxkbcommon)*
- `cargo +nightly clippy -- -D warnings` *(fails: missing system library libxkbcommon)*
- `cargo +nightly doc --no-deps` *(fails: missing system library libxkbcommon)*
- `cargo audit`
- `cargo deny check` *(fails: unable to fetch advisory database due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68d9dc7670f4832bbfd772df24973fb5